### PR TITLE
[CPL-25151] Add ecom, finance, sales, and report-generation skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 !/marketing/
 /marketing/*
 !/marketing/marketing-analytics/
+!/analytics/
+!/reporting/

--- a/analytics/ecom-analytics.md
+++ b/analytics/ecom-analytics.md
@@ -1,0 +1,157 @@
+---
+name: ecom-analytics
+description: Use this skill when the user wants to analyze e-commerce performance, review funnel conversion, investigate AOV or repeat-purchase trends, build an ecom report, check sales velocity, understand customer cohorts and retention, or answer questions about their store's sales data. Triggers include 'how is my store performing', 'what's my conversion rate', 'cart abandonment', 'AOV trend', 'repeat purchase rate', 'why did revenue drop', 'cohort retention', 'top products', 'new vs returning customer revenue', 'lifetime value', 'pull my Shopify numbers', 'ecom report'.
+---
+
+# Ecom Analytics
+
+Analyze e-commerce performance using data from Coupler.io dataflows (Shopify, WooCommerce, BigCommerce, Magento, GA4, Stripe, Klaviyo, etc.). This skill guides you through retrieving order/session data, computing funnel and revenue metrics, detecting anomalies, and presenting actionable insights an ecom operator can act on.
+
+## Step 0: Context Check (Pre-requisite)
+
+Before starting any analysis, the **Data Context Check** skill (`generate-data-set-context`) runs as a gate. It calls `get-schema` on each target dataset to determine whether meaningful context (column descriptions, business rules, metric definitions, e.g. how returns are flagged, currency conventions, what counts as a 'completed' order) is attached.
+
+- If context exists → proceed to Step 1.
+- If context is missing → the user is offered the option to generate it first.
+
+Do not duplicate this check in Step 1d. If the context check skill has already run and context is present, Step 1d should use the enriched schema directly.
+
+## Step 1: Discover and Select Data Sources
+
+Every analysis starts by connecting to the user's data through Coupler.io MCP tools.
+
+### 1a. Discover available data
+
+Default to `search-datasets` with ecom-flavored keywords — `shopify`, `woocommerce`, `bigcommerce`, `magento`, `orders`, `gmv`, `ecom`, `klaviyo`, `ga4`, `stripe`, or whatever store/source the user named. Search keeps the response small and lands on the right dataflow when the domain is known (which it is, by definition, when this skill is loaded).
+
+Fall back to `list-datasets` only when the user is genuinely browsing or hasn't given any source/keyword to anchor on. Each dataflow represents a data pipeline (e.g. "Shopify Orders", "GA4 Ecommerce Events", "Klaviyo Email Engagement", "Stripe Charges", "WooCommerce Sales").
+
+### 1b. Select relevant datasets
+
+How you handle selection depends on the match clarity, not just the count:
+
+**Unambiguous match (1 dataflow, clearly matches the request)** → use it. Mention which one you're using in your output. No confirmation needed.
+
+**Obvious candidates (2–3 dataflows clearly relevant)** → state your selection with one-line reasoning. Proceed but invite corrections.
+
+**Ambiguous (5+ dataflows, or unclear which subset matters)** → present your best candidates (up to 5–7) grouped by source/scope, with reasoning, and wait for confirmation:
+
+```
+I found 3 dataflows likely relevant to your repeat-purchase question:
+  1. shopify_orders — has customer_id, order date, line items
+  2. klaviyo_engagement — email touchpoints around purchases
+  3. ga4_ecommerce — session-level conversion data
+Should I use all three, or focus on one?
+```
+
+**Hard gate only when ambiguous:** wait for user confirmation when the right datasets aren't obvious. If you're confident and stated your reasoning, proceed — the user can redirect you.
+
+### 1c. Get dataflow details
+
+For each selected dataset, call `get-dataflow` to read its current state — sources, destinations, last run, schedule. Note data freshness (when the dataflow last ran) so you can mention it in the output.
+
+### 1d. Understand the data structure
+
+Call `get-schema` on each target dataset. If context was generated in Step 0, use the enriched schema directly. Otherwise build a mental mapping between `columnName` (used in SQL) and `label` (used when communicating).
+
+For ecom-specific schemas, watch for these critical column families: `order_id`, `customer_id`/`email`, `created_at`/`processed_at`, `total`/`subtotal`/`tax`/`shipping`, `currency`, `financial_status` (paid/refunded/partially-refunded), `fulfillment_status`, `line_items` (often nested), `discount_codes`, `customer_segment` (new/returning).
+
+### 1e. Sample the data
+
+Sample each dataset to verify contents. For wide tables (>15 columns), sample only the columns relevant to the analysis. Flag anything off (empty columns, unexpected formats, null-heavy fields, refund flags missing, etc.) before proceeding.
+
+## Step 2: Compute Metrics via SQL
+
+Always compute metrics via SQL in `get-data`. Floating-point aggregations over thousands of rows in-context are unreliable; the Coupler.io SQL engine handles this correctly.
+
+### Working with multiple datasets
+
+**Date alignment:** Different sources use different date formats and grains (Shopify: ISO timestamp; GA4: date string; Stripe: Unix). Aggregate to a common grain before comparing.
+
+**Currency normalization:** Multi-currency stores need explicit normalization (always confirm the conversion source/rate with the user before reporting).
+
+**Refund handling — critical:** Decide upfront whether you're reporting `gross revenue` (includes refunded orders), `net revenue` (excludes refunds), or `paid revenue` (excludes pending). The user often doesn't realize these differ. State your choice in the output and check the assumption.
+
+**New vs. returning customers:** If joining order data with customer history, define 'new' explicitly (first-ever order in the data window vs. first order in the analysis window). Flag the choice.
+
+**Joining sessions and orders:** Web session data (GA4) and order data (Shopify) often don't share a join key. Be explicit about whether you're presenting them side-by-side (no join) or attempting an attribution join (typically requires `client_id` or UTM consistency).
+
+## Step 3: Draft Findings and Get User Feedback
+
+Before generating a full analysis, present a brief summary — the 3–5 most important numbers, anomalies, and direction. Wait for the user's response before continuing.
+
+## Step 4: Build the Analysis
+
+Based on what the user asked for, follow the appropriate analysis path:
+
+### Funnel Analysis
+
+Quantify the path from visit → product view → add to cart → checkout → purchase. Key stages and standard metrics:
+
+- **Conversion rate (overall)** — purchases / sessions for the period.
+- **Add-to-cart rate** — add-to-cart events / product views.
+- **Cart-to-checkout rate** — checkouts initiated / carts.
+- **Checkout-to-purchase rate** — completed purchases / checkouts initiated. (Cart abandonment = 1 - this rate, by convention.)
+
+Identify the biggest drop-off stage. A funnel with strong product-view → add-to-cart but weak checkout → purchase signals checkout friction (shipping cost surprise, payment issues, account-required friction). A weak product-view → add-to-cart suggests product/pricing/imagery issues.
+
+Flag asymmetries: if mobile and desktop convert very differently, present them separately.
+
+### Cohort & Retention Analysis
+
+Group customers by acquisition month/week. Compute repeat-purchase rate at month 1, 2, 3, 6, 12. Healthy ecom businesses see clear retention plateaus; declining cohorts signal product/experience issues.
+
+Report the curve, not just a single number. "Month-3 repeat rate has dropped from 22% (Q1) to 14% (Q3)" tells the operator more than "repeat rate is 14%".
+
+### AOV / Revenue Mix
+
+- **AOV (Average Order Value)** = total revenue / number of orders. Track period-over-period.
+- **AOV by segment** — new vs. returning customers, channels, geographies, top SKUs. Returning customers should typically have higher AOV; if not, investigate.
+- **Revenue mix** — share of revenue from new vs. returning customers, top 10 SKUs vs. long tail, full-price vs. discounted. Concentrations >40% in any single SKU/channel are risk concentrations to flag.
+- **Discount load** — share of orders/revenue using a discount code. If creeping up over time, margin is at risk.
+
+### Repeat Purchase / Lifetime Value
+
+- **Repeat purchase rate** — share of customers with 2+ orders in the window.
+- **Days between purchases (median)** — gives a sense of replenishment cadence.
+- **Customer LTV proxy** — average revenue per customer cohort over a fixed window (e.g., 12-month LTV).
+
+Distinguish between LTV (true lifetime, requires long history) and windowed LTV (proxy, comparable across cohorts). Always state the window.
+
+### Anomaly Detection and Metric Investigations
+
+Any time the analysis involves investigating a change, drop, or spike — whether the user explicitly asks 'why did revenue drop' or you notice unusual patterns during a routine report — apply this framework:
+
+**Severity classification:**
+- **Informational** — within 1 standard deviation of trailing 4-week average, or <10% change. Note it.
+- **Warning** — 1–2 standard deviations, or 10–30% change. Investigate, present hypotheses.
+- **Critical** — >2 standard deviations, >30% change, or any metric collapsing to zero. Lead with this finding.
+
+**Baseline comparison:** Compare against same day-of-week last week, trailing 4-week average for the same day-of-week, and same period last year (seasonality matters a lot in ecom — Black Friday, holiday, Mother's Day, back-to-school).
+
+**Root cause investigation steps:**
+1. **Isolate the scope** — one channel, one product, one geo, or everything? Break down by available dimensions.
+2. **Check data freshness** — did the dataflow actually run? Partial-day data masquerading as a 'drop' is the most common false alarm.
+3. **Check upstream changes** — site speed, payment provider issues, inventory stockouts, paid traffic pauses, email send pauses, promo schedule changes.
+4. **Check for data issues** — duplicate orders, refund spikes counted as new orders, currency conversion bugs.
+5. **Present hypotheses ranked by likelihood** — "Most likely: SKU X stocked out on the 12th, accounts for 60% of the revenue drop. Less likely: paid social CPM spike (only 8% of acquisition)."
+
+## Step 5: Present Results
+
+Lead with the headline, use plain language, ensure every finding has a 'So what?' and 'Now what?', structure for scannability.
+
+**Abbreviation expansion:** First time using AOV, LTV, CAC, ROAS, CR, etc. — expand it. After first use, the abbreviation alone is fine.
+
+**Currency:** Always state the currency on first use. If multi-currency, normalize and state the conversion approach.
+
+## Rules & Edge Cases
+
+- Always mention data freshness (when the dataflow last ran) before presenting metrics. A report on 5-day-old ecom data needs that context.
+- State revenue convention (gross/net/paid) on first use; never silently switch mid-analysis.
+- Refunds and chargebacks: if not in scope of the data, say so explicitly. Don't pretend net revenue when you only have gross.
+- Returning customer definitions: when in doubt, ask. 'New within window' vs. 'first ever' produce very different cohort numbers.
+- Inventory/stockouts: a revenue drop with no traffic drop is almost always a stockout or pricing change — check inventory data if available.
+- Partial-week comparisons: never compare a full week to a partial week without flagging it. Same for partial month, partial quarter.
+- Promotion effects: Black Friday week, sale-week promotions, and first-purchase discounts skew AOV and CR. Call out the promo context when comparing periods that include/exclude them.
+- Round numbers appropriately: AOV/revenue to whole currency units for large values; rates to 1 decimal percent.
+- If a dataflow's last execution failed or is stale (>1 day for a daily-refresh ecom flow, >12h for hourly), warn the user before proceeding.

--- a/analytics/finance-analytics.md
+++ b/analytics/finance-analytics.md
@@ -1,0 +1,159 @@
+---
+name: finance-analytics
+description: Use this skill when the user wants to analyze financial performance, review P&L health, monitor MRR/ARR, investigate margin or cost trends, build a finance report, check cash flow or runway, or answer questions about their accounting/billing data. Triggers include 'how is revenue trending', 'gross margin', 'MRR breakdown', 'churn impact on ARR', 'why did costs go up', 'operating expenses', 'cash runway', 'P&L review', 'EBITDA', 'cost per acquisition trend', 'pull my QuickBooks numbers', 'finance report'.
+---
+
+# Finance Analytics
+
+Analyze financial performance using data from Coupler.io dataflows (QuickBooks, Xero, Stripe, NetSuite, Sage, billing systems). This skill guides you through retrieving accounting and revenue data, computing P&L, margin, subscription, and cash metrics, detecting anomalies, and presenting actionable insights a finance lead can act on.
+
+## Step 0: Context Check (Pre-requisite)
+
+Before starting any analysis, the **Data Context Check** skill (`generate-data-set-context`) runs as a gate. It calls `get-schema` on each target dataset to determine whether meaningful context (chart of accounts mapping, entity/subsidiary structure, currency conventions, fiscal calendar, accrual vs. cash convention) is attached.
+
+- If context exists → proceed to Step 1.
+- If context is missing → the user is offered the option to generate it first.
+
+Do not duplicate this check in Step 1d.
+
+## Step 1: Discover and Select Data Sources
+
+### 1a. Discover available data
+
+Default to `search-datasets` with finance-flavored keywords — `quickbooks`, `xero`, `netsuite`, `stripe`, `sage`, `gl`, `invoice`, `revenue`, `mrr`, `arr`, `bank`, or whatever system the user named. Search keeps the response small and lands on the right dataflow when the domain is known.
+
+Fall back to `list-datasets` only when the user is genuinely browsing or hasn't given any source/keyword to anchor on. Each dataflow represents a data pipeline (e.g. "QuickBooks GL", "Stripe Charges", "NetSuite Revenue", "Xero Invoices", "Bank Transactions").
+
+### 1b. Select relevant datasets
+
+**Unambiguous match (1 dataflow)** → use it; mention which one.
+
+**Obvious candidates (2–3)** → state your selection with one-line reasoning, proceed but invite corrections.
+
+**Ambiguous (5+, or unclear)** → present best candidates (up to 5–7) grouped by source/scope, with reasoning, and wait for confirmation:
+
+```
+I found 3 dataflows likely relevant to your MRR question:
+  1. stripe_subscriptions — has plan, MRR amount, status
+  2. quickbooks_gl — has revenue accounts, but at journal grain
+  3. salesforce_opportunities — has booked ARR, less useful for recognized
+Should I use Stripe alone, or combine Stripe and QuickBooks for cross-check?
+```
+
+**Hard gate only when ambiguous.** If you're confident and stated reasoning, proceed.
+
+### 1c. Get dataflow details
+
+Call `get-dataflow` for each candidate. Note `schedule` (data freshness), source health, and the close status of any GL data — finance refreshes are often slower than transactional sources.
+
+### 1d. Understand the data structure
+
+Call `get-schema` on each target dataset. If context was generated in Step 0, use the enriched schema directly.
+
+For finance schemas, watch for these critical column families: account/account_code (chart of accounts), entity_id/subsidiary, currency, transaction_date/posting_date, amount (signed: positive = credit, varies by source), invoice_status (paid/open/voided), customer_id, plan_id, billing_period_start/end, refund flags.
+
+### 1e. Sample the data
+
+Sample each dataset to verify contents. Watch specifically for: signed-amount conventions (debit-positive vs. credit-positive), currency mixing, journal entry duplicates, voided/reversed entries that need exclusion. Flag anything off before proceeding.
+
+## Step 2: Compute Metrics via SQL
+
+Always compute via SQL in `get-data`. Floating-point aggregations over thousands of rows in-context are unreliable.
+
+### Working with multiple datasets
+
+**Date alignment:** Posting date vs. transaction date vs. service date can differ — confirm which the user wants. Use fiscal calendar if the company doesn't operate on calendar months.
+
+**Currency normalization:** Multi-entity companies need consolidation; always state your conversion approach (period-end FX vs. average FX vs. native).
+
+**Cash vs. accrual:** Critical distinction. Confirm which convention the user wants. Stripe data is mostly cash; QuickBooks/NetSuite GL can be either depending on configuration.
+
+**Recognized vs. booked:** Booked = contract signed (Salesforce). Billed = invoice issued. Recognized = ASC 606 revenue recognition (subscription pro-ration). Don't conflate; ask if unclear.
+
+**Voided/reversed entries:** GL data often includes voided journals — exclude them in the WHERE clause. Don't double-count refunds as new revenue.
+
+## Step 3: Draft Findings and Get User Feedback
+
+Before generating a full analysis, present a brief summary — the 3–5 most important numbers, anomalies, and direction. Wait for user response before continuing.
+
+## Step 4: Build the Analysis
+
+### P&L Review
+
+Standard structure: Revenue → COGS → Gross Profit → Operating Expenses → Operating Income → Other → Net Income.
+
+- **Gross margin %** = (Revenue − COGS) / Revenue. Track period-over-period; a 2-point compression is meaningful.
+- **Operating margin %** = Operating Income / Revenue.
+- **Expense breakdown by category** (Sales & Marketing, R&D, G&A) — flag categories growing faster than revenue.
+- Period-over-period and year-over-year comparisons. State the comparison basis explicitly.
+
+Flag concentration: if one customer/product is >20% of revenue, call it out as a concentration risk.
+
+### MRR / ARR & Subscription Health
+
+For SaaS or subscription businesses:
+
+- **MRR** = sum of monthly recurring revenue across active subscriptions. ARR = MRR × 12.
+- **MRR movement bridge**: Starting MRR + New + Expansion + Reactivation − Contraction − Churn = Ending MRR. Always reconcile the bridge — gaps reveal data issues or missing categories.
+- **Net Revenue Retention (NRR)** = (Starting MRR of cohort + Expansion − Contraction − Churn) / Starting MRR. Healthy SaaS: >100%.
+- **Gross Revenue Retention (GRR)** = (Starting MRR − Contraction − Churn) / Starting MRR. Excludes expansion.
+- **Logo churn vs. revenue churn** — present both; high logo churn with stable revenue churn signals SMB churn masked by enterprise stability.
+
+### Cash & Runway
+
+- **Cash burn (monthly)** = avg monthly net cash outflow over trailing 3 months.
+- **Runway** = current cash balance / monthly burn. State both calendar months and 'months at current burn'.
+- **Operating cash flow vs. net income** — divergences signal AR/AP timing issues.
+
+If bank/cash data isn't in scope, say so. Don't extrapolate runway from P&L data without cash data.
+
+### Cost-Center Investigation
+
+When the user asks 'why did costs go up' or 'where is spend growing fastest':
+
+1. Break down the cost category by sub-account or vendor.
+2. Compare to prior period at the sub-account level.
+3. Identify the top 3 sub-accounts driving the change.
+4. Check for one-time items (annual renewals, project spikes) vs. structural increases.
+5. Present: "Of the $X increase, $Y is from <vendor/account> renewing on annual cycle, $Z is structural increase in <category>, balance is distributed."
+
+### Anomaly Detection and Metric Investigations
+
+Any time the analysis involves investigating a change, drop, or spike — apply this framework:
+
+**Severity classification:**
+- **Informational** — within 1 SD of trailing 4-month average, or <5% change. Note it.
+- **Warning** — 1–2 SD, or 5–15% change. Investigate, present hypotheses.
+- **Critical** — >2 SD, >15% change, or any metric crossing a covenant/threshold. Lead with this finding.
+
+Finance has tighter sensitivity than marketing/ecom — a 10% gross margin drop is a 'critical' event, not 'warning'.
+
+**Baseline comparison:** Same period prior year (annual seasonality matters in finance), trailing 3-month average, budget if available.
+
+**Root cause investigation steps:**
+1. **Isolate the scope** — which entity, which account, which customer/vendor.
+2. **Check posting period** — late-arriving journals, period-end accruals, reversal entries.
+3. **Check upstream changes** — pricing changes, contract renewals, vendor changes, new accounting policy.
+4. **Check for data issues** — duplicate journals, currency conversion errors, voided entries not excluded.
+5. **Present hypotheses ranked by likelihood** — "Most likely: annual security audit fee posted to G&A in this month vs. amortized last year. Less likely: structural growth in headcount cost."
+
+## Step 5: Present Results
+
+Lead with the headline, use plain language, ensure every finding has a 'So what?' and 'Now what?', structure for scannability.
+
+**Abbreviation expansion:** First use of MRR, ARR, NRR, GRR, EBITDA, COGS, GAAP, ASC 606, AR, AP, FX — expand it.
+
+**Currency:** Always state on first use. If multi-currency, state your normalization approach (period-end vs. average FX, source of rates).
+
+**Materiality:** Note material vs. immaterial movements. A $5 swing in a $50M revenue line is noise.
+
+## Rules & Edge Cases
+
+- Always state data freshness and the close status (preliminary, soft-closed, hard-closed) before presenting numbers. Pre-close numbers can shift materially.
+- State revenue convention (cash, accrual, recognized) on first use; never silently switch.
+- Voided/reversed journals must be excluded from totals. If you can't tell which entries are voided, say so.
+- Multi-entity / multi-currency: never sum across entities without consolidation. State your consolidation approach.
+- Prior-period adjustments and reclassifications: if a prior month was restated, mention it — comparing current period to a restated prior gives different results than to the original.
+- Round to materiality: don't report margins to 4 decimals when 1 decimal is enough. Don't report dollar amounts to the cent on totals over $10K.
+- Tax: distinguish pre-tax and post-tax metrics explicitly when both exist.
+- If a dataflow's last execution failed or is stale (>2 days for a daily GL refresh), warn the user — and consider that GL data is often refreshed less frequently than transactional sources, so 'stale' definitions differ.

--- a/analytics/sales-analytics.md
+++ b/analytics/sales-analytics.md
@@ -1,0 +1,151 @@
+---
+name: sales-analytics
+description: Use this skill when the user wants to analyze sales pipeline, review win rates, investigate sales velocity or cycle length, build a sales report, evaluate rep performance, look at lead source quality, or answer questions about their CRM data. Triggers include 'how is the pipeline', 'win rate by segment', 'sales cycle', 'pipeline coverage', 'rep performance', 'forecast accuracy', 'why are deals stalling', 'lead source quality', 'stage conversion', 'pull my Salesforce numbers', 'HubSpot deals report', 'sales report'.
+---
+
+# Sales Analytics
+
+Analyze sales performance using data from Coupler.io dataflows (Salesforce, HubSpot, Pipedrive, Close, Zoho, custom CRMs). This skill guides you through retrieving opportunity/deal data, computing pipeline and conversion metrics, investigating velocity and rep performance, detecting anomalies, and presenting actionable insights a sales leader can act on.
+
+## Step 0: Context Check (Pre-requisite)
+
+Before starting any analysis, the **Data Context Check** skill (`generate-data-set-context`) runs as a gate. It calls `get-schema` on each target dataset to determine whether meaningful context is attached — particularly stage definitions, segment mappings (SMB/MM/Enterprise), team/territory structure, lead source taxonomy, and how 'closed-lost no decision' is distinguished from 'closed-lost competitive'.
+
+- If context exists → proceed to Step 1.
+- If context is missing → the user is offered the option to generate it first.
+
+Do not duplicate this check in Step 1d.
+
+## Step 1: Discover and Select Data Sources
+
+### 1a. Discover available data
+
+Default to `search-datasets` with sales-flavored keywords — `salesforce`, `hubspot`, `pipedrive`, `close`, `zoho`, `opportunities`, `deals`, `pipeline`, `leads`, `activities`, or whatever CRM the user named. Search keeps the response small and lands on the right dataflow when the domain is known.
+
+Fall back to `list-datasets` only when the user is genuinely browsing or hasn't given any source/keyword to anchor on. Each dataflow represents a CRM data pipeline (e.g. "Salesforce Opportunities", "HubSpot Deals", "Pipedrive Pipeline", "Salesforce Activities", "Lead Sources").
+
+### 1b. Select relevant datasets
+
+**Unambiguous match (1 dataflow)** → use it; mention which one.
+
+**Obvious candidates (2–3)** → state your selection with one-line reasoning, proceed but invite corrections.
+
+**Ambiguous (5+, or unclear)** → present best candidates (up to 5–7) grouped by source/scope, with reasoning, and wait for confirmation:
+
+```
+I found 4 dataflows likely relevant to your win-rate question:
+  1. salesforce_opportunities — full pipeline with stage history
+  2. hubspot_deals — older deals not migrated to SF
+  3. salesforce_activities — calls/emails per opportunity
+  4. closed_lost_reasons — categorized loss reasons
+Should I focus on 1 alone, or include 4 to break down the loss reasons?
+```
+
+**Hard gate only when ambiguous.**
+
+### 1c. Get dataflow details
+
+Call `get-dataflow` for each candidate. Note `schedule`, source health, and last successful run — CRM extracts can lag, and pipeline snapshots become misleading fast.
+
+### 1d. Understand the data structure
+
+Call `get-schema` on each target dataset. If context was generated in Step 0, use the enriched schema directly.
+
+For sales/CRM schemas, watch for: opportunity_id, account_id, owner_id, stage, stage_history (rare; often requires snapshots), amount/expected_amount, close_date, created_date, won/lost flags, lead_source, segment, territory, probability. Stage history is the load-bearing one for cycle/conversion analysis — if it's missing, flag that some metrics will be approximations.
+
+### 1e. Sample the data
+
+Sample each dataset. Watch for: deals stuck in legacy stages, missing close_date on open deals, amount in mixed currencies, deals tagged closed-won but with empty amount (services or trials), duplicate deal records across systems.
+
+## Step 2: Compute Metrics via SQL
+
+Always compute via SQL in `get-data`.
+
+### Working with multiple datasets
+
+**Date alignment:** created_date, last_modified, close_date, stage_change_date — confirm which the user wants. 'Pipeline as of date X' typically uses close_date filtered by stage status as of X (requires snapshot history).
+
+**Currency normalization:** Multi-currency CRMs need conversion (most have a currency field per opportunity). State your conversion approach.
+
+**Open vs. closed:** Be explicit which population you're analyzing. 'Pipeline' usually means open deals. 'Win rate' usually means closed (won + lost) deals — open deals don't count yet.
+
+**Snapshot vs. live:** Live CRM data is point-in-time current. To compute 'pipeline as of last quarter', you need historical snapshots (often via daily extracts). Without snapshots, you can only approximate using created_date and close_date.
+
+## Step 3: Draft Findings and Get User Feedback
+
+Before generating a full analysis, present a brief summary — top 3–5 findings, anomalies, direction. Wait for user response.
+
+## Step 4: Build the Analysis
+
+### Pipeline Review
+
+Snapshot the current open pipeline:
+
+- **Total pipeline value** — sum of open deal amounts, weighted (× probability) and unweighted.
+- **Stage distribution** — count and value by stage. Healthy pipeline shows progression; bunched-at-stage-1 signals a stalled top-of-funnel.
+- **Pipeline coverage** = (open pipeline closing in period) / (target for period). Healthy: 3x for the current quarter.
+- **Aging** — days in current stage. Deals stuck >2x average stage time are at risk.
+- **Top 10 deals** — biggest open deals with stage, age, owner, expected close. Always show the leaderboard, even if the user didn't ask.
+
+### Win Rate Investigation
+
+- **Overall win rate** = closed-won / (closed-won + closed-lost) for the period.
+- **By segment** — SMB/MM/Enterprise rates often differ 2–3x; report separately.
+- **By source** — inbound vs. outbound vs. partner can differ wildly.
+- **By rep** — flag outliers (best, worst), but caveat with sample size — a rep with 4 deals doesn't have a meaningful rate.
+- **Loss reason analysis** — if loss reasons are tagged, group them: price, product fit, no-decision, competitive, timing. No-decision losses signal qualification issues; competitive losses signal product/positioning issues.
+
+### Velocity & Cycle Analysis
+
+- **Sales velocity** = (# open opportunities × avg deal size × win rate) / sales cycle length (days). Quarterly velocity in $/day is a leading indicator.
+- **Sales cycle (median days)** — created_date to close_date for closed-won deals. Use median, not mean — a few mega-deals skew the mean.
+- **Stage cycle** — median days per stage. Identifies the bottleneck stage.
+- **Stage conversion** — share of deals that progress from stage N to stage N+1 (vs. dying in stage N). Requires stage history; without it, approximate using created→won transitions.
+
+### Rep Performance
+
+- **Quota attainment** — actual / quota for the period. Distribution across the team matters more than the average.
+- **Activity metrics** — calls, emails, meetings per rep (if activity data is connected). Correlate to outcomes; high activity / low conversion signals quality issues.
+- **Win rate, avg deal size, cycle length** per rep, with sample size caveat.
+- **Pipeline-built per rep** — leading indicator for next period's bookings.
+
+Never single out a rep negatively without enough data (n>10 closed deals minimum). Frame development opportunities, not failures.
+
+### Anomaly Detection and Metric Investigations
+
+Apply this framework whenever investigating a change, drop, or spike (e.g., 'why did our win rate drop'):
+
+**Severity classification:**
+- **Informational** — within 1 SD of trailing-quarter average, or <5pp change in rate metrics. Note it.
+- **Warning** — 1–2 SD, or 5–10pp change. Investigate, present hypotheses.
+- **Critical** — >2 SD, >10pp change, or pipeline coverage dropping below 2x. Lead with this finding.
+
+**Baseline comparison:** Same quarter prior year (sales has annual cycles), trailing 4-quarter average, target/budget.
+
+**Root cause investigation steps:**
+1. **Isolate the scope** — one segment, one source, one team, one product line, or everything?
+2. **Check data freshness** — are recent stage changes recorded? CRM hygiene gaps make 'metric drops' that are really data gaps.
+3. **Check upstream changes** — territory realignment, comp plan changes, pricing updates, product launches/sunsets, marketing source mix shifts.
+4. **Check for data issues** — bulk-edited deals, duplicates, deals reassigned mid-cycle, stage definitions changed.
+5. **Present hypotheses ranked by likelihood** — "Most likely: enterprise segment win rate dropped 12pp, accounts for 80% of the overall drop. Less likely: rep churn — only 2 reps left this quarter."
+
+## Step 5: Present Results
+
+Lead with the headline. Plain language. Every finding gets a 'So what?' and 'Now what?'
+
+**Abbreviation expansion:** First use of CRM, ACV, ARR, MQL, SQL (sales-qualified lead, NOT structured query language — disambiguate if both meanings could apply), CAC, NRR — expand.
+
+**Sample size caveats:** When breaking down by rep/source/segment, state n. "Inbound has a 28% win rate (n=42) vs outbound's 14% (n=8)."
+
+## Rules & Edge Cases
+
+- Always state data freshness (when the dataflow last ran) and whether the period is in-progress or closed.
+- Open vs. closed populations: never silently mix them. 'Pipeline win rate' is almost always nonsense — open deals don't have outcomes yet.
+- Probability fields: confirm whether they're rep-set or stage-derived. Rep-set probabilities are often inflated.
+- Stage definitions: stage names like 'Discovery' or 'Negotiation' mean different things at different companies — defer to the user's stage glossary if context exists.
+- Multi-currency: state your normalization. Don't sum amounts across currencies without conversion.
+- Snapshots: if doing historical analysis without snapshot data, say so. "This 'pipeline as of Q1' is approximated from created_date and stage; without daily snapshots, deals that moved stage mid-quarter are counted at their final stage, not their Q1-end stage."
+- Channel/source double-counting: deals with both inbound and outbound activity may be tagged inconsistently. Pick one source-of-truth field per analysis and stick to it.
+- Rep attribution: if territory or owner changed mid-deal, state how you're attributing the win/loss.
+- Sample-size minimums: per-rep stats with n<10 closed deals are noise — use them to spot patterns, not for performance reviews.
+- If a dataflow's last execution failed or is stale (>1 day for daily-refresh CRM data), warn the user.

--- a/reporting/report-generation.md
+++ b/reporting/report-generation.md
@@ -1,0 +1,213 @@
+---
+name: report-generation
+description: Use this skill to produce a structured business report from analysis output and validate it before delivery — turning metrics, findings, and recommendations into a scannable, decision-ready document, then sanity-checking arithmetic, units, claims, and consistency. Industry-agnostic; works for marketing, ecom, finance, sales, or any analytics output. Compose with a domain bundle (e.g., ecom-analytics + report-generation) for domain-flavored reports. Triggers include 'write a report', 'summarize this analysis', 'put this in a report format', 'create a TL;DR', 'monthly business review', 'weekly performance report', 'executive summary', 'structured update on …', 'turn this into a report', 'sanity-check these numbers', 'validate this analysis', 'does this add up', 'review this for accuracy'.
+---
+
+# Report Generation
+
+Produce a structured, decision-ready report from analysis output, then validate it before delivery. The skill has two phases: **Phase 1 drafts the report**, **Phase 2 checks it**. Run both, in order, every time. The skill is industry-agnostic — it formats and verifies findings; it does not generate data or analysis. The data and analysis come from the domain bundle loaded alongside (e.g. `marketing-analytics`, `ecom-analytics`, `finance-analytics`, `sales-analytics`).
+
+## When to use this skill
+
+- The user asked for a "report", "summary", "review", or "TL;DR".
+- The user asked for a structured deliverable they can share or act on.
+- A complex analysis is complete and needs to be packaged for an audience.
+- The user asked to "sanity-check", "validate", or "review for accuracy" an existing draft. In that case, **skip Phase 1** and go straight to Phase 2 against the draft they provided.
+
+Not needed for direct data requests ("show me top 5 rows") — those return the data and stop.
+
+## Composition
+
+If a domain bundle is loaded in the same turn, use its terminology, metric idioms, severity thresholds, and edge-case rules. Do not duplicate or override the bundle's decisions. If no domain bundle is loaded but the request is clearly domain-flavored (mentions ROAS, MRR, AOV, win rate, CAC, etc.), recommend loading the relevant bundle by name before producing the report.
+
+---
+
+# Phase 1 — Draft the report
+
+## Required inputs (from the analysis)
+
+Before drafting, confirm you have:
+
+- The metric values, with source dataset, timeframe, and freshness.
+- The comparison basis (period-over-period, year-over-year, vs. target/budget) — if used.
+- Anomalies and their severity (informational / warning / critical), per the loaded domain bundle's framework.
+- Hypotheses or root causes the analysis surfaced.
+- The audience (operator, lead, executive) — if not stated, ask in one sentence; default to "operator-level".
+
+If any are missing and the analysis can still be summarized usefully, proceed and call out what's missing in the report's caveats.
+
+## Output structure
+
+Use this structure unless the user asked for a different format. Adapt section depth to the complexity of the analysis — a simple weekly update may have one-line sections; an MBR may run a paragraph each.
+
+### 1. TL;DR (1–3 sentences)
+
+The single most important thing the audience needs to know. State direction (up/down/flat), magnitude, and severity. Lead with the most material number.
+
+Example: "Revenue is **down 18%** week-over-week (warning), driven primarily by a stockout on SKU-1024 starting Monday. All other product lines are within normal range."
+
+### 2. Key Metrics (3–5 metrics, no more)
+
+Each metric in this format:
+
+- **Metric name (with definition on first use)**: **value** | period-over-period change (absolute and %) | direction indicator
+- One-line context: why this number, what it means, or what changed
+
+Exclude metrics that didn't materially change unless their stability is itself the headline. Format numbers with markdown bold: **$48,200**, **17.2%**, **2.4x**. State data freshness once at the top of this section, not per-metric.
+
+### 3. Context (paragraph or 2–3 bullets)
+
+The story behind the numbers. Trends, anomalies, comparisons. This is where domain-bundle insight goes — root-cause hypotheses, segment breakdowns, what changed in the environment. If there are anomalies, present them ranked by severity (critical → warning → informational). Cite the data: "Mobile CR dropped from 2.4% to 1.7% over the past 7 days (n=14k sessions)." For cross-period comparisons, always state both periods and confirm they're comparable (full vs. partial, with vs. without promo, same vs. different fiscal week).
+
+### 4. Recommendations (2–3 specific actions, prioritized)
+
+Each recommendation:
+
+- **The action** — concrete, verb-led ("Re-enable the paused SKU-1024 inventory feed").
+- **Why** — the data signal that motivates it.
+- **Expected impact** — directional ("would recover ~$8K of weekly revenue if stockout was the only cause") or qualitative.
+
+If there's only one critical action, recommend just that. Don't pad to three. If there are no clear recommendations because the analysis is informational, say so — do not invent advice.
+
+### 5. Next Questions (1–3 questions)
+
+The most useful follow-up questions the user could ask next. These should narrow scope, deepen a thread, or extend to adjacent data.
+
+## Tone and format
+
+- Concise. A weekly report is a page or less. An MBR is 2–3 pages max.
+- Plain language. Define abbreviations on first use.
+- Bold for numbers, sparingly bold for emphasis. No emoji except 📈 📉 💡.
+- Second person (you/your), first person (I/my).
+- Match the user's tone — professional-direct for operators, more contextual for executives.
+- Never use ordinal numbers in section bullets. No "You're absolutely right" or apologetic preambles.
+
+## Required statements (always present)
+
+- Source dataset(s) and timeframe used (e.g. `shopify_orders`, week of April 21–27, 2026).
+- Data freshness — when the dataflow last ran successfully.
+- Currency, if monetary values are reported.
+- Any caveat about partial periods, stockouts, data-pipeline issues, or attribution windows that affects interpretation.
+
+## Phase 1 rules & edge cases
+
+- Never fabricate numbers, recommendations, or hypotheses. If the analysis didn't produce something, the report doesn't claim it.
+- Never silently change unit conventions (currency, gross/net, day/week grain) within a report. State once and stick to it.
+- If the analysis output had warnings about data quality (stale dataflow, voided journals, tracking gaps), surface those warnings in the Caveats — do not hide them.
+- If the report covers a period in progress (current week, current month), say so explicitly: "Week-to-date through Wednesday".
+- If the user requested Slack-formatted output, use Slack Block Kit JSON and Slack markdown (`*bold*`, not `**bold**`). Otherwise default to standard markdown.
+- If the analysis produced fewer than 3 actionable findings, prefer a shorter report — don't pad to fill sections.
+
+---
+
+# Phase 2 — Validate the draft
+
+After drafting (or when the user hands you an existing draft to check), run every validation category below before delivery. The goal is to catch mistakes the prior step might have made: arithmetic errors, unit drift, claims the underlying data doesn't actually support, period-comparison fallacies. This phase does NOT generate new analysis or numbers — it checks what's already there.
+
+## Phase 2 inputs
+
+- The draft report.
+- The source data (or the SQL queries and their results) the report was built from. If the queries' results aren't in context, re-run them to verify.
+- The domain bundle's framework (for severity thresholds and metric definitions).
+
+If the source data isn't recoverable (e.g. context-trimmed), say so explicitly and validate only what's locally checkable (arithmetic, internal consistency, units).
+
+## Validation checks
+
+Run each check. For each, output PASS or list specific issues.
+
+### 1. Arithmetic
+
+- Sums add up. Channel totals = reported total (within rounding).
+- Percentages are correct. "Revenue grew 18%" means new/old − 1 = 0.18; verify.
+- Period-over-period deltas: absolute change matches percentage change.
+- Weighted averages computed correctly. Don't average the averages without weighting.
+- Conversion / efficiency ratios: numerator and denominator from the same scope (e.g. CPA = spend / conversions, both scoped to the same campaign and period).
+- Re-execute any non-trivial computation explicitly in the response. Don't trust internal arithmetic on unfamiliar numbers — show the math.
+
+### 2. Units & conventions
+
+- Currency: same throughout, or normalized with a stated approach. No silent USD-to-EUR mixing.
+- Time period: same window applied to all comparable metrics. No mixing "last week" and "last 7 days".
+- Counts vs. rates: a "rate" must be on a stated denominator. Don't confuse percentage points (pp) and percent change.
+- Gross vs. net: ecom revenue / margin / etc. — the report must state and stick to one convention.
+- Cash vs. accrual / booked vs. recognized: finance reports need explicit basis.
+- Probability-weighted vs. raw values: sales pipeline numbers need the basis stated.
+
+### 3. Claim vs. data
+
+For every numeric or directional claim, trace it to a query result:
+
+- "Revenue is up 18%" — find the query, recompute, confirm.
+- "Ecom funnel conversion dropped" — confirm with funnel-stage data, not just session totals.
+- "Top performer was Campaign X" — confirm from the per-campaign table, with full-quartile context.
+- Severity claims ("critical", "warning", "informational") must align with the loaded domain bundle's severity thresholds.
+
+If a claim cannot be traced to a query result, FLAG IT for removal or rewording.
+
+### 4. Internal consistency
+
+- TL;DR matches Key Metrics — the headline number and direction should match what the metrics section reports.
+- Recommendations flow from the findings — every recommendation should reference data signals actually surfaced earlier in the report.
+- Caveats are consistent — if the report flagged stale data in Section 3, it shouldn't reference "real-time" anywhere.
+- Comparison basis is consistent — "vs. last week" and "vs. trailing 4-week average" are different baselines; don't switch silently.
+
+### 5. Logical gates
+
+Common fallacies to flag:
+
+- **Period mismatch** — comparing a partial week/month to a full one without flagging.
+- **Open vs. closed populations** — computing win rates on open deals (only closed deals have outcomes).
+- **Survivorship bias** — analyzing "top customers" without acknowledging churned ones are excluded.
+- **Selection bias** — "campaigns we kept have higher ROAS than campaigns we cut" (yes, that's why they were cut).
+- **Sample size** — segment-level rates with n<10 should carry a caveat.
+- **Attribution conflation** — summing platform-reported conversions across Google + Meta + LinkedIn double-counts.
+- **Spurious precision** — reporting a margin to 4 decimals on a sample of 50 transactions implies false confidence.
+- **Causation from correlation** — "CTR rose after creative refresh" is a correlation; if causal language is used, it should be flagged or softened.
+
+### 6. Citation completeness
+
+Every numeric claim should be traceable to:
+
+- A named dataset (e.g. `shopify_orders`).
+- A stated timeframe.
+- A noted data freshness.
+
+Missing any of these → flag for fix.
+
+## Phase 2 output
+
+Internal output, not shown to the user unless they explicitly asked for a validation pass:
+
+```
+Validation: PASS
+- Arithmetic: ✓ (re-checked: 18% delta = $48,200 vs. $40,800)
+- Units: ✓ (USD throughout, week-grain consistent)
+- Claim vs. data: ✓ (5 claims traced to source queries)
+- Consistency: ✓ (TL;DR matches metrics)
+- Logical gates: ✓ (no period mismatches, sample sizes adequate)
+- Citations: ✓ (dataset + timeframe + freshness present)
+```
+
+If issues are found, list each with: where in the report (section / line), what's wrong, what to do. Then fix in the draft and re-run validation. Do not present a report that hasn't passed cleanly.
+
+```
+Validation: ISSUES FOUND (3)
+
+1. Arithmetic — Section 2 Key Metrics: claimed 18% growth, but ($48,200 / $40,800) − 1 = 18.14%, which rounds to 18% (acceptable). Note: Section 1 TL;DR says "nearly 20%" — overstated; align to 18%.
+
+2. Units — Section 3 Context: mixed "last week" and "last 7 days" for the same comparison. Pick one and apply consistently.
+
+3. Logical gate — Section 4 Recommendation 2: "Cut Campaign Beta, win rate is 8%" — Campaign Beta has only 3 closed deals (n=3, below 10-deal minimum). Either remove the recommendation or reframe as "Campaign Beta is underperforming on a small sample; gather more data before deciding."
+```
+
+When the user explicitly asked to validate (not generate), present the result as the response. Otherwise, fix issues silently in the draft and deliver the corrected report.
+
+## Phase 2 rules & edge cases
+
+- Never invent corrections to numbers you can't verify against source data. Flag for removal or for the user to confirm — don't guess at the "right" value.
+- Don't second-guess the domain bundle's framework. If `marketing-analytics` says 30% change is "critical", a 25% change is "warning" — accept those thresholds.
+- Validation is conservative: when in doubt, flag. The cost of a false-positive is small; the cost of a false-negative is a wrong report shipped.
+- If after a fix the report still has issues, re-run validation. Don't deliver a report that hasn't passed cleanly.
+- For Slack-formatted output, validate the JSON structure as well as content (Block Kit syntactically valid, blocks under 11,950 chars).
+- If multiple datasets or domain bundles were loaded, confirm the report uses each correctly and doesn't conflate metric definitions across domains (e.g. "churn" means different things in finance/SaaS vs. ecom).


### PR DESCRIPTION
[Ticket link](https://railsware.atlassian.net/browse/CPL-25151)

### Problem/domain

The `coupler-io/skills` repo currently only ships marketing-flavored skills, but the langfuse-managed prompt library (`coupler-io-langfuse` on `CPL-25151/skill-library-v2`) already has four production-ready analytics skills: ecom, finance, sales, and a domain-agnostic report-generation skill. They need to live in this repo so Claude Code users can install them as plugins alongside `marketing-analytics`.

### Tech changes

- Add three domain analytics skills under `analytics/` — `ecom-analytics.md`, `finance-analytics.md`, `sales-analytics.md`.
- Add the industry-agnostic `report-generation.md` skill under `reporting/`.
- Source files were copied from `coupler-io-langfuse/prompts/ai-agents/skills/`, with frontmatter rewritten from Langfuse format (`_langfuse`, `config.description`, `name: ai-agents/skills/...`, `tags`, `type`) to Claude Code skill format (`name` + `description`). Body content unchanged.
- Extend `.gitignore` allowlist with `!/analytics/` and `!/reporting/` so the new top-level categories are tracked.

### How to test

1. Check out the branch locally.
2. `cat analytics/ecom-analytics.md | head -5` — confirm frontmatter has only `name` and `description` (no Langfuse keys).
3. Repeat for `analytics/finance-analytics.md`, `analytics/sales-analytics.md`, `reporting/report-generation.md`.
4. Install the repo as a Claude Code plugin (or copy any skill folder into `.claude/skills/`) and verify the skill activates on its trigger phrases (e.g. "build me an ecom report", "MRR breakdown", "weekly performance report").
5. `git ls-files analytics reporting` should list exactly 4 files.

### How to deploy

Standard merge to `main`. No migrations, env vars, or feature flags. The skills are picked up automatically by the marketplace manifest once they live under tracked top-level folders.