### PR TITLE
Add metadata to SKILL.md files

### DIFF
--- a/capability/create-dataflow/SKILL.md
+++ b/capability/create-dataflow/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: create-dataflow
 description: "Use this skill when the user wants to create a new dataflow, set up a new data import, connect a new data source to a destination, pull data from an integration into Google Sheets or BigQuery or another destination, or configure a source-to-destination data pipeline. Triggers include: 'import my HubSpot data', 'set up a Stripe export', 'create a pipeline from X to Y', 'I want to pull data from [source]', 'create a new dataflow', 'connect [source] to [destination]', 'set up a data flow for [source]'."
+metadata:
+  category: capability
+  sources: []
 ---
 
 # Create Dataflow

--- a/capability/generate-data-set-context/SKILL.md
+++ b/capability/generate-data-set-context/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: generate-data-set-context
 description: "Use this skill when the user wants to explore a dataset's context, or write or update documentation for the data it holds. Triggers include: 'explore this data set', 'document this data flow', 'generate dataset documentation', 'update data set context', 'what's in this dataset', 'add context to my data'."
+metadata:
+  category: capability
+  sources: []
 ---
 
 # Generate Data Set Context

--- a/capability/get-started/SKILL.md
+++ b/capability/get-started/SKILL.md
@@ -13,6 +13,8 @@ description: >-
   create-dataflow skill instead).
 metadata:
   version: 0.1.0
+  category: capability
+  sources: []
 ---
 
 # Get Started

--- a/capability/refine-prompt/SKILL.md
+++ b/capability/refine-prompt/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: refine-prompt
 description: "Use this skill when the user's request is vague, incomplete, or poorly structured and needs to be sharpened into a detailed, actionable analytics prompt before analysis. Triggers include underspecified asks like 'how's my marketing doing', 'show me sales data', 'what campaigns performed best' — requests missing a time period, explicit metrics, data sources, comparison criteria, or output format."
+metadata:
+  category: capability
+  sources: []
 ---
 
 # Refine Prompt

--- a/capability/report-generation/SKILL.md
+++ b/capability/report-generation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: report-generation
 description: Use this skill to produce a structured business report from analysis output and validate it before delivery — turning metrics, findings, and recommendations into a scannable, decision-ready document, then sanity-checking arithmetic, units, claims, and consistency. Industry-agnostic; works for marketing, ecom, finance, sales, or any analytics output. Compose with a domain bundle (e.g., ecom-analytics + report-generation) for domain-flavored reports. Triggers include 'write a report', 'summarize this analysis', 'put this in a report format', 'create a TL;DR', 'monthly business review', 'weekly performance report', 'executive summary', 'structured update on …', 'turn this into a report', 'sanity-check these numbers', 'validate this analysis', 'does this add up', 'review this for accuracy'.
+metadata:
+  category: capability
+  sources: []
 ---
 
 # Report Generation

--- a/ecommerce/ecom-analytics/SKILL.md
+++ b/ecommerce/ecom-analytics/SKILL.md
@@ -6,9 +6,8 @@ metadata:
   sources:
     - Shopify
     - WooCommerce
-    - BigCommerce
-    - Magento
-    - GA4
+    - Adobe Commerce (Magento)
+    - Google Analytics 4 (GA4)
     - Stripe
     - Klaviyo
 ---

--- a/ecommerce/ecom-analytics/SKILL.md
+++ b/ecommerce/ecom-analytics/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: ecom-analytics
 description: Use this skill when the user wants to analyze e-commerce performance, review funnel conversion, investigate AOV or repeat-purchase trends, build an ecom report, check sales velocity, understand customer cohorts and retention, or answer questions about their store's sales data. Triggers include 'how is my store performing', 'what's my conversion rate', 'cart abandonment', 'AOV trend', 'repeat purchase rate', 'why did revenue drop', 'cohort retention', 'top products', 'new vs returning customer revenue', 'lifetime value', 'pull my Shopify numbers', 'ecom report'.
+metadata:
+  category: ecommerce
+  sources:
+    - Shopify
+    - WooCommerce
+    - BigCommerce
+    - Magento
+    - GA4
+    - Stripe
+    - Klaviyo
 ---
 
 # Ecom Analytics

--- a/finance/finance-analytics/SKILL.md
+++ b/finance/finance-analytics/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   sources:
     - QuickBooks
     - Xero
-    - NetSuite
+    - Oracle NetSuite
     - Stripe
     - Sage
 ---

--- a/finance/finance-analytics/SKILL.md
+++ b/finance/finance-analytics/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: finance-analytics
 description: Use this skill when the user wants to analyze financial performance, review P&L health, monitor MRR/ARR, investigate margin or cost trends, build a finance report, check cash flow or runway, or answer questions about their accounting/billing data. Triggers include 'how is revenue trending', 'gross margin', 'MRR breakdown', 'churn impact on ARR', 'why did costs go up', 'operating expenses', 'cash runway', 'P&L review', 'EBITDA', 'cost per acquisition trend', 'pull my QuickBooks numbers', 'finance report'.
+metadata:
+  category: finance
+  sources:
+    - QuickBooks
+    - Xero
+    - NetSuite
+    - Stripe
+    - Sage
 ---
 
 # Finance Analytics

--- a/marketing-and-ads/marketing-analytics/SKILL.md
+++ b/marketing-and-ads/marketing-analytics/SKILL.md
@@ -9,6 +9,12 @@ description: >
   skill instead — this skill owns the cross-channel view.
 metadata:
   version: 0.1.1
+  category: marketing-and-ads
+  sources:
+    - Google Ads
+    - Facebook Ads
+    - LinkedIn Ads
+    - GA4
 ---
 
 # Marketing Analytics

--- a/marketing-and-ads/marketing-analytics/SKILL.md
+++ b/marketing-and-ads/marketing-analytics/SKILL.md
@@ -12,9 +12,9 @@ metadata:
   category: marketing-and-ads
   sources:
     - Google Ads
-    - Facebook Ads
+    - Facebook Ads (Meta Ads)
     - LinkedIn Ads
-    - GA4
+    - Google Analytics 4 (GA4)
 ---
 
 # Marketing Analytics

--- a/marketing-and-ads/ppc-analytics/SKILL.md
+++ b/marketing-and-ads/ppc-analytics/SKILL.md
@@ -13,6 +13,10 @@ description: >
   report-generation.
 metadata:
   version: 0.2.0
+  category: marketing-and-ads
+  sources:
+    - Facebook Ads
+    - Google Ads
 ---
 
 # Paid Ads Performance Analysis (PPC)

--- a/marketing-and-ads/ppc-analytics/SKILL.md
+++ b/marketing-and-ads/ppc-analytics/SKILL.md
@@ -15,7 +15,7 @@ metadata:
   version: 0.2.0
   category: marketing-and-ads
   sources:
-    - Facebook Ads
+    - Facebook Ads (Meta Ads)
     - Google Ads
 ---
 

--- a/sales/sales-analytics/SKILL.md
+++ b/sales/sales-analytics/SKILL.md
@@ -7,8 +7,8 @@ metadata:
     - Salesforce
     - HubSpot
     - Pipedrive
-    - Close
-    - Zoho
+    - Close.com
+    - Zoho CRM
 ---
 
 # Sales Analytics

--- a/sales/sales-analytics/SKILL.md
+++ b/sales/sales-analytics/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: sales-analytics
 description: Use this skill when the user wants to analyze sales pipeline, review win rates, investigate sales velocity or cycle length, build a sales report, evaluate rep performance, look at lead source quality, or answer questions about their CRM data. Triggers include 'how is the pipeline', 'win rate by segment', 'sales cycle', 'pipeline coverage', 'rep performance', 'forecast accuracy', 'why are deals stalling', 'lead source quality', 'stage conversion', 'pull my Salesforce numbers', 'HubSpot deals report', 'sales report'.
+metadata:
+  category: sales
+  sources:
+    - Salesforce
+    - HubSpot
+    - Pipedrive
+    - Close
+    - Zoho
 ---
 
 # Sales Analytics

--- a/utilities/coupler-live-artifact/SKILL.md
+++ b/utilities/coupler-live-artifact/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: coupler-live-artifact
 description: Build a live Cowork artifact (persistent HTML widget) backed by a Coupler.io dataflow. Use this skill whenever the user wants a live dashboard, persistent widget, daily-check page, or interactive explorer over Coupler.io data — including phrases like "live artifact for Coupler", "Coupler dashboard widget", "build a widget over a Coupler dataset", "Coupler.io live dashboard", "build a daily dashboard from a Coupler dataflow", or any time they ask to render Coupler data in a re-openable view that auto-refreshes. Triggers even when the user does not say "skill" or "artifact" but describes the same outcome (e.g. "I want a page I can check every morning that pulls my Coupler data").
+metadata:
+  category: utilities
+  sources: []
 ---
 
 # Coupler.io live artifact

--- a/utilities/humanizer/skills/humanizer/SKILL.md
+++ b/utilities/humanizer/skills/humanizer/SKILL.md
@@ -8,6 +8,9 @@ description: >
   AI-sounding language. Also activate after generating any written content when
   the user has asked for natural or human-sounding output.
 version: 0.1.0
+metadata:
+  category: utilities
+  sources: []
 ---
 
 # Humanizer


### PR DESCRIPTION
Add a metadata YAML block (category and sources) to multiple SKILL.md files to standardize skill metadata. Several domain skills were populated with integration sources (ecom: Shopify, WooCommerce, BigCommerce, Magento, GA4, Stripe, Klaviyo; finance: QuickBooks, Xero, NetSuite, Stripe, Sage; marketing: Google Ads, Facebook Ads, LinkedIn Ads, GA4; ppc: Facebook Ads, Google Ads; sales: Salesforce, HubSpot, Pipedrive, Close, Zoho). Other capability and utility skills received an empty sources array. These are documentation/metadata updates only.