### PR TITLE
Fix broken marketplace.json and the false install instructions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
         "./marketing-and-ads/tiktok-ads/tiktok-ads-structure-and-learning-review",
         "./marketing-and-ads/tiktok-ads/tiktok-ads-placement-geo-and-device",
         "./marketing-and-ads/tiktok-ads/tiktok-ads-gmv-max-and-shop-review",
-        "./marketing-and-ads/tiktok-ads/tiktok-ads-client-report"
+        "./marketing-and-ads/tiktok-ads/tiktok-ads-client-report",
         "./marketing-and-ads/facebook-ads/facebook-ads-performance-review",
         "./marketing-and-ads/facebook-ads/facebook-ads-waste-and-scale",
         "./marketing-and-ads/facebook-ads/facebook-ads-creative-analysis",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,5 @@
 {
   "name": "coupler-io-skills",
-  "id": "coupler-io-skills",
   "owner": {
     "name": "Coupler.io"
   },

--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ Each ICP is its own plugin, so you install only what you need. Available plugins
 
 Plugin skills are namespaced by their plugin, so they can be invoked explicitly as `/coupler-finance:finance-analytics`. Most of them are model-invoked too — Claude reaches for them when the request matches their description. If the install summary says `Run /reload-plugins to activate.`, run that.
 
+**Install only the plugin you need.** Every skill's description stays in context for the whole session, so a plugin's cost scales with how many skills it carries. `coupler-marketing-ads` bundles 32 and adds roughly 5.5k tokens to every session; the single-skill plugins add a few hundred. Check any plugin before installing it:
+
+```
+claude plugin details coupler-marketing-ads@coupler-io-skills
+```
+
 **For a whole team** — register the marketplace in the repository's `.claude/settings.json` so collaborators get it once they trust the folder:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -175,19 +175,28 @@ Each ICP is its own plugin, so you install only what you need. Available plugins
 | `coupler-finance` | finance-analytics |
 | `coupler-sales` | sales-analytics |
 | `coupler-ecommerce` | ecom-analytics |
-| `coupler-marketing-ads` | marketing-analytics, ppc-analytics, + the 8 Google Ads and 11 TikTok Ads deep dives |
+| `coupler-marketing-ads` | marketing-analytics, ppc-analytics, + the 8 Google Ads, 11 Meta / Facebook Ads and 11 TikTok Ads deep dives |
 | `coupler-capability` | get-started, create-dataflow, google-ads-custom-gaql, generate-data-set-context, refine-prompt, report-generation |
 | `coupler-utilities` | coupler-live-artifact |
 | `humanizer` | humanizer (+ `/humanize` command) |
 
-**As a Claude Code plugin (repo-wide)** — add to your `.claude/settings.json`:
+Plugin skills are namespaced by their plugin, so they can be invoked explicitly as `/coupler-finance:finance-analytics`. Most of them are model-invoked too — Claude reaches for them when the request matches their description. If the install summary says `Run /reload-plugins to activate.`, run that.
+
+**For a whole team** — register the marketplace in the repository's `.claude/settings.json` so collaborators get it once they trust the folder:
 
 ```json
 {
-  "plugins": [
-    "https://github.com/coupler-io/skills"
-  ]
+  "extraKnownMarketplaces": {
+    "coupler-io-skills": {
+      "source": {
+        "source": "github",
+        "repo": "coupler-io/skills"
+      }
+    }
+  }
 }
 ```
 
-**Manual** — copy any skill folder (each contains a `SKILL.md`) into your project's `.claude/skills/` directory. The skill activates automatically when its trigger phrases are matched.
+This adds the marketplace, not the plugins. Each person still runs `/plugin install <plugin>@coupler-io-skills` to pick what they want. To pre-enable plugins as well, see [`enabledPlugins`](https://code.claude.com/docs/en/settings-reference#plugin-settings).
+
+**Manual** — copy any skill folder (each contains a `SKILL.md`) into your project's `.claude/skills/` directory. Skills installed this way are not namespaced, and Claude activates them when the request matches their description.


### PR DESCRIPTION
## What

Three problems on the path a new user takes first. The `marketplace.json` one means installation is broken on `main` right now.

## 1. `marketplace.json` does not parse

```json
"./marketing-and-ads/tiktok-ads/tiktok-ads-client-report"      ← missing comma
"./marketing-and-ads/facebook-ads/facebook-ads-performance-review",
```

`python -c "import json; json.load(open('.claude-plugin/marketplace.json'))"` fails with `Expecting ',' delimiter: line 70`. Since the manifest is what `/plugin marketplace add` reads, **step one of the README does not work today.**

It came from the #12 / #13 merge: both PRs appended to the same `coupler-marketing-ads` skills array, and the keep-both resolution missed the comma.

## 2. The install table lost the Meta pack

The row read "the 8 Google Ads and 11 TikTok Ads deep dives". TikTok's version of that line won the same merge and Meta's mention went with it, even though the Meta section sits above it in the same file.

## 3. The repo-wide install snippet was not real

The README told users to add this to `.claude/settings.json`:

```json
{ "plugins": ["https://github.com/coupler-io/skills"] }
```

**There is no top-level `plugins` key.** The documented key is `extraKnownMarketplaces`, and it takes a named source object, not a list of URLs:

```json
{
  "extraKnownMarketplaces": {
    "coupler-io-skills": {
      "source": { "source": "github", "repo": "coupler-io/skills" }
    }
  }
}
```

Also added the caveat the docs are explicit about: registering a marketplace **does not install its plugins**. Each person still runs `/plugin install <plugin>@coupler-io-skills`. `enabledPlugins` is linked for pre-enabling.

Verified against [code.claude.com/docs/en/discover-plugins](https://code.claude.com/docs/en/discover-plugins). I also checked the local machine — no `plugins` key exists in `~/.claude/settings.json` or `~/.claude.json`.

## What was already right

- **The first block.** `/plugin marketplace add coupler-io/skills` then `/plugin install <plugin>@coupler-io-skills` is correct; the marketplace name after the `@` is the `name` field in `marketplace.json`, which is `coupler-io-skills`.
- **The manual option.** Copying a skill folder into `.claude/skills/` is the documented standalone approach.
- **The manifest's own structure.** `source: "./"`, the `skills` array and `strict` are all valid plugin-entry fields per the [marketplace reference](https://code.claude.com/docs/en/plugin-marketplaces), so nothing beyond the comma needed changing.

## Added

A line noting plugin skills are namespaced (`/coupler-finance:finance-analytics`) while manually copied ones are not — an invisible difference otherwise — and that `/reload-plugins` may be needed.

## Tested end to end

Not just JSON-parsed — run against the real CLI.

| Test | `main` | This branch |
|---|---|---|
| `claude plugin validate` | ✘ Validation failed — `Invalid JSON syntax: Expected ']'` | ✔ Validation passed |
| `claude plugin marketplace add ./` | ✘ Failed to add marketplace — `JSON Parse error` | ✔ `Successfully added marketplace: coupler-io-skills` |
| `claude plugin install coupler-marketing-ads@coupler-io-skills` | — | ✔ `Successfully installed (scope: user)` |
| Components loaded | — | 32 skills, 0 agents/hooks/MCP/LSP |

The break is confirmed at the real entry point: anyone following the README against `main` hits a parse error on step one. The corrected path works, including the `@coupler-io-skills` marketplace name. Tested against a local path marketplace, so the git clone step is not covered; the plugin and marketplace were uninstalled afterwards.

## Two more fixes from that test

- **Removed the unknown `id` field.** `claude plugin validate` warned `Unknown field 'id'. Claude Code ignores it at load time.` The manifest had both `name` and `id` set to the same string; only `name` is in the schema. Validation now passes clean rather than with warnings.
- **Documented context cost.** `claude plugin details` reports **~5,567 tokens always-on, added to every session** for `coupler-marketing-ads`, since each of its 32 skills keeps its description in context. Nothing in the README mentioned it. The Installation section now says to install only what you need, gives the figure, and shows the command to check any plugin first.

## Note on #14

#14 also fixes the comma and the Meta row, since it hit the same conflict. This PR is split out so the correctness fixes can merge without waiting on #14's review. Once this lands I will rebase #14 to drop the duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

