### PR TITLE
Facebook Ads pack: render inline visuals instead of offering them

### DIFF
--- a/marketing-and-ads/facebook-ads/facebook-ads-audience-analysis/SKILL.md
+++ b/marketing-and-ads/facebook-ads/facebook-ads-audience-analysis/SKILL.md
@@ -43,7 +43,8 @@ start by admitting what it is reading, and most audience reporting quietly does 
 → one combined query. **Two calls** when the dataset is known.
 
 Overriding rules: never spend a call proving the connection works; speak at the coverage read;
-missing data is a line in the write-up, not a gate; don't narrate steps.
+missing data is a line in the write-up, not a gate; don't narrate steps; render rankings, trends and
+splits as inline visuals in the message rather than offering to make them.
 
 ## A. Connect to Coupler.io (HARD GATE)
 
@@ -134,16 +135,48 @@ Metrics = spend, results and cost per result by group, plus the unclassified sha
 naming convention assumed, the incrementality caveat, volume floors · Recommendations = which groups
 to expand, which to question, each with the number behind it.
 
+### Inline visuals (REQUIRED)
+
+**Render these in the message itself. They are not an offer and not a follow-up** — a ranking, a
+trend or a split of a total delivered as prose is a defect in this skill's output.
+
+Scale bars from zero. Put the unit and the scale maximum on a label line above the visual. Cap at
+eight rows and roll the rest into `Other (n)`. Mark rows under the volume floor rather than drawing
+them to scale, and never bar a rate without its denominator in the row. **The visual replaces the
+prose it would have taken** — one sentence of interpretation underneath, never a restatement of the
+rows.
+
+Forms: unicode bar (`█`, scaled to the largest row) for rankings and splits; sparkline
+(`▁▂▃▄▅▆▇█`, first and last values labelled) for five or more periods; mermaid for structure only,
+never for quantity.
+
+| Whenever the run produced | Render |
+|---|---|
+| Three or more audience groups above the floor | Unicode bar of cost per result, cheapest first, results count in each row |
+| A spend split across groups | Unicode bar of share of spend, with `Unclassified` always shown as its own row and never folded into `Other` |
+| Five or more weeks of ageing for one group | Two sparklines stacked over the same weeks — cost per result, then frequency — so the point where they cross is visible |
+| An age or gender split with three or more cells above the floor | Unicode bar of cost per result by cell, raw results in the row |
+
+**Render nothing** when there is a single figure, fewer than three comparable rows, an early exit,
+or a coverage table dominated by "not checkable". A two-row bar trains the reader to skip the
+visuals on the runs that have eight.
+
 ## G. Offer to build it out (CONDITIONAL)
+
+**The inline visuals above are not optional and are not this section's business.** This section
+covers only what *leaves the conversation* — a written record, a brief, a document, a pack. It
+**stays silent unless the run produced something a document carries better than the message already
+did.**
 
 | Found | Worth making | Why |
 |---|---|---|
-| Four or more audience groups with different cost per result | A comparison chart, cost per result by group | Three-way and wider comparisons are what charts are for |
-| A measured ageing curve | Cost per result and frequency over weeks, on one chart | The crossing point is the finding |
-| An age or gender split with clear structure | A demographic grid | Reads faster than prose and the floors are visible |
+| An expand-or-question list going to whoever will action it | A written record with the group definitions and the incrementality caveat | The caveat has to travel with the recommendation or the group gets scaled blind |
+| A naming convention that had to be assumed | A written note of the assumed convention for the account file | The next run and the next person both need it |
 
-**Stay silent when** the naming convention did not parse, there is one group, or "not checkable"
-dominates coverage. One thing, named by what it contains and who it is for. Never build it unasked.
+**Stay silent when** the naming convention did not parse, there is one group, "not checkable"
+dominates coverage, or the inline visuals above already carried the finding. One thing, named by
+what it contains and who it is for — never a menu. Never build it unasked; never delay the answer to
+make it.
 
 ## H. Save what you learned
 

--- a/marketing-and-ads/facebook-ads/facebook-ads-budget-pacing/SKILL.md
+++ b/marketing-and-ads/facebook-ads/facebook-ads-budget-pacing/SKILL.md
@@ -43,7 +43,8 @@ Manager tells you almost nothing about where the month ends.
 → one combined query. **Two calls** when the dataset is already known.
 
 Overriding rules: never spend a call proving the connection works; speak at the coverage read; treat
-missing data as a line in the write-up rather than a gate; don't narrate steps.
+missing data as a line in the write-up rather than a gate; don't narrate steps; render rankings,
+trends and splits as inline visuals in the message rather than offering to make them.
 
 ## A. Connect to Coupler.io (HARD GATE)
 
@@ -143,17 +144,46 @@ date, projected month end, budget, variance in currency and percent, required da
 coverage, the budget's provenance, ad sets excluded for learning · Recommendations = the reallocation
 lines with a ceiling on each.
 
+### Inline visuals (REQUIRED)
+
+**Render these in the message itself. They are not an offer and not a follow-up** — a ranking, a
+trend or a split of a total delivered as prose is a defect in this skill's output.
+
+Scale bars from zero. Put the unit and the scale maximum on a label line above the visual. Cap at
+eight rows and roll the rest into `Other (n)`. Mark rows under the volume floor rather than drawing
+them to scale, and never bar a rate without its denominator in the row. **The visual replaces the
+prose it would have taken** — one sentence of interpretation underneath, never a restatement of the
+rows.
+
+Forms: unicode bar (`█`, scaled to the largest row) for rankings and splits; sparkline
+(`▁▂▃▄▅▆▇█`, first and last values labelled) for five or more periods; mermaid for structure only,
+never for quantity.
+
+| Whenever the run produced | Render |
+|---|---|
+| A month-to-date spend path over five or more days | Sparkline of daily spend, first and last labelled, with the required daily figure and the projected month end written out beside it |
+| Three or more campaigns with different pacing verdicts | Unicode bar of spend to date as a share of each campaign's own budget, the verdict word in the row |
+| A reallocation of more than two lines | Two unicode bars of the same total — before, then after — in the same line order |
+
+**Render nothing** when there is a single figure, fewer than three comparable rows, an early exit,
+or a coverage table dominated by "not checkable". A two-row bar trains the reader to skip the
+visuals on the runs that have eight.
+
 ## H. Offer to build it out (CONDITIONAL)
+
+**The inline visuals above are not optional and are not this section's business.** This section
+covers only what *leaves the conversation* — a written record, a brief, a document, a pack. It
+**stays silent unless the run produced something a document carries better than the message already
+did.**
 
 | Found | Worth making | Why |
 |---|---|---|
-| A projection against budget over the month | A pacing chart, actual against required run rate | The gap is a shape, and everyone reads it faster than a sentence |
-| Four or more campaigns with different pacing verdicts | A pacing status table by campaign | Splits a total three ways at a glance |
-| A reallocation going to someone who was not in this conversation | A written record for the account file | It has to survive being forwarded |
+| A reallocation going to someone who was not in this conversation | A written record with each line, its ceiling and its reason | Half-actioned reallocations come from missing ceilings |
 
-**Stay silent when** pacing is inside the band, there is one finding, or "not checkable" dominates
-coverage. One thing, named by what it contains and who it is for. If the client pack is what they
-want, route to `facebook-ads-client-report`. Never build it unasked.
+**Stay silent when** pacing is inside the band, there is one finding, "not checkable" dominates
+coverage, or the inline visuals above already carried the finding. One thing, named by what it
+contains and who it is for — never a menu. If the client pack is what they want, route to
+`facebook-ads-client-report`. Never build it unasked; never delay the answer to make it.
 
 ## I. Save what you learned
 

--- a/marketing-and-ads/facebook-ads/facebook-ads-client-report/SKILL.md
+++ b/marketing-and-ads/facebook-ads/facebook-ads-client-report/SKILL.md
@@ -45,7 +45,8 @@ its number and the caveats are stated once, plainly, rather than hedged through 
 pack.
 
 Overriding rules: never spend a call proving the connection works; speak at the coverage read;
-missing data becomes a line in the appendix, not a mid-run question; don't narrate steps.
+missing data becomes a line in the appendix, not a mid-run question; don't narrate steps; render
+rankings, trends and splits as inline visuals in the pack rather than offering to make them.
 
 ## A. Connect to Coupler.io (HARD GATE)
 
@@ -161,20 +162,49 @@ Never deliver a client pack that has not passed.
 Round consistently and do not imply precision the data does not have. A cost per result quoted to two
 decimal places on eleven conversions is a claim the document cannot support.
 
+### Inline visuals (REQUIRED)
+
+**Render these in the message itself. They are not an offer and not a follow-up** — a ranking, a
+trend or a split of a total delivered as prose is a defect in this skill's output.
+
+Scale bars from zero. Put the unit and the scale maximum on a label line above the visual. Cap at
+eight rows and roll the rest into `Other (n)`. Mark rows under the volume floor rather than drawing
+them to scale, and never bar a rate without its denominator in the row. **The visual replaces the
+prose it would have taken** — one sentence of interpretation underneath, never a restatement of the
+rows.
+
+Forms: unicode bar (`█`, scaled to the largest row) for rankings and splits; sparkline
+(`▁▂▃▄▅▆▇█`, first and last values labelled) for five or more periods; mermaid for structure only,
+never for quantity.
+
+| Whenever the run produced | Render |
+|---|---|
+| KPI performance against target across three or more metrics | Unicode bar per metric, actual against target on the same scale, the gap in currency or percent in the row |
+| Three or more months of a headline metric | Sparkline on that metric's KPI-table line, first and last labelled |
+| A spend split across campaigns or objectives | Unicode bar of share of the month's spend, top seven plus `Other (n campaigns)` |
+
+**Render nothing** when there is a single figure, fewer than three comparable rows, an early exit,
+or a coverage table dominated by "not checkable". A two-row bar trains the reader to skip the
+visuals on the runs that have eight.
+
+**In a client pack specifically:** the Summary carries at most two visuals — more and the client
+reads none of them. The misses section always carries the target-against-actual bar for the metric
+that missed; a miss explained only in prose reads as a miss being buried. The appendix carries the
+rest. Every visual in a pack that leaves the building is validated by Phase 2 like any other claim.
+
 ## H. Offer to build it out (CONDITIONAL)
 
-Here the offer is more likely to fire than anywhere else in the pack, because the output leaves the
-building by design.
+**The inline visuals above are not optional and are not this section's business.** This section
+covers only what *leaves the conversation* — a written record, a brief, a document, a pack. It
+**stays silent unless the run produced something a document carries better than the message already
+did.**
 
 | Found | Worth making | Why |
 |---|---|---|
-| A complete pack for an external client | The formatted document or deck | It is the deliverable, not an extra |
-| KPI performance against target across several metrics | A target-versus-actual chart for the summary slide | Clients read the chart first |
-| A trend across three or more months | The trend line | Context the table cannot carry |
+| A complete pack for an external client | The formatted document or deck, in the format the client receives | It is the deliverable, not an extra |
 
-**Offer one thing.** The pack itself, in the format the client receives. Do not offer a menu of four
-formats to somebody who is already late for a meeting. Never build it unasked, and never delay the
-written answer to make it.
+**Stay silent when** there is nothing to send outward. One thing, named by what it contains and who
+it is for — never a menu. Never build it unasked; never delay the answer to make it.
 
 ## I. Save what you learned
 

--- a/marketing-and-ads/facebook-ads/facebook-ads-creative-analysis/SKILL.md
+++ b/marketing-and-ads/facebook-ads/facebook-ads-creative-analysis/SKILL.md
@@ -45,7 +45,8 @@ different work.
 → one combined query. **Two calls** when the dataset is known.
 
 Overriding rules: never spend a call proving the connection works; speak at the coverage read;
-missing data is a line in the write-up, not a gate; don't narrate steps.
+missing data is a line in the write-up, not a gate; don't narrate steps; render rankings, trends and
+splits as inline visuals in the message rather than offering to make them.
 
 ## A. Connect to Coupler.io (HARD GATE)
 
@@ -137,17 +138,45 @@ per outcome for the top and bottom three, hook rate, hold rate, the funnel step 
 coverage, volume floors, the rankings caveat · Recommendations = the production brief, plus which ads
 to keep funding.
 
+### Inline visuals (REQUIRED)
+
+**Render these in the message itself. They are not an offer and not a follow-up** — a ranking, a
+trend or a split of a total delivered as prose is a defect in this skill's output.
+
+Scale bars from zero. Put the unit and the scale maximum on a label line above the visual. Cap at
+eight rows and roll the rest into `Other (n)`. Mark rows under the volume floor rather than drawing
+them to scale, and never bar a rate without its denominator in the row. **The visual replaces the
+prose it would have taken** — one sentence of interpretation underneath, never a restatement of the
+rows.
+
+Forms: unicode bar (`█`, scaled to the largest row) for rankings and splits; sparkline
+(`▁▂▃▄▅▆▇█`, first and last values labelled) for five or more periods; mermaid for structure only,
+never for quantity.
+
+| Whenever the run produced | Render |
+|---|---|
+| Four or more ads above the results floor | Unicode bar of cost per outcome, ranked, the account average stated on the label line, results count in each row |
+| Hook rate and hold rate across three or more videos | Two unicode bars stacked in the same ad order — hook, then hold — so the drop-off per ad is readable down the column |
+| A funnel step-rate diagnosis | Unicode bar per step for the best and worst ad, the step where they diverge marked in the row |
+
+**Render nothing** when there is a single figure, fewer than three comparable rows, an early exit,
+or a coverage table dominated by "not checkable". A two-row bar trains the reader to skip the
+visuals on the runs that have eight.
+
 ## G. Offer to build it out (CONDITIONAL)
+
+**The inline visuals above are not optional and are not this section's business.** This section
+covers only what *leaves the conversation* — a written record, a brief, a document, a pack. It
+**stays silent unless the run produced something a document carries better than the message already
+did.**
 
 | Found | Worth making | Why |
 |---|---|---|
-| Six or more ads with a spread of cost per outcome | A ranked bar with the account average marked | A distribution is a shape |
-| A funnel diagnosis across several ads | A step-rate comparison grid | Shows at a glance which ads fail at which step |
-| A video hook and hold comparison | A two-axis plot, hook against hold | The quadrants are the brief |
-| A production brief going to a designer or agency | A written creative brief for the next round | It leaves the conversation, so it has to stand alone |
+| A production brief going to a designer or agency | A written creative brief for the next round | It stands alone outside the conversation, and the brief is the ask |
 
-**Stay silent when** there are two ads, results are below the floor, or "not checkable" dominates.
-One thing, named by what it contains and who it is for. Never build it unasked.
+**Stay silent when** there are two ads, results are below the floor, "not checkable" dominates, or
+the inline visuals above already carried the finding. One thing, named by what it contains and who
+it is for — never a menu. Never build it unasked; never delay the answer to make it.
 
 ## H. Save what you learned
 

--- a/marketing-and-ads/facebook-ads/facebook-ads-creative-fatigue/SKILL.md
+++ b/marketing-and-ads/facebook-ads/facebook-ads-creative-fatigue/SKILL.md
@@ -44,7 +44,8 @@ replacement creative has not been briefed, so the account limps for another fort
 → one combined query. **Two calls** when the dataset is known.
 
 Overriding rules: never spend a call proving the connection works; speak at the coverage read;
-missing data is a line in the write-up, not a gate; don't narrate steps.
+missing data is a line in the write-up, not a gate; don't narrate steps; render rankings, trends and
+splits as inline visuals in the message rather than offering to make them.
 
 ## A. Connect to Coupler.io (HARD GATE)
 
@@ -138,16 +139,46 @@ the refresh queue with days remaining, frequency, CTR against baseline, lifespan
 coverage, the volume floor, ads excluded for recent edits · Recommendations = the refresh queue and
 the production cadence with its arithmetic.
 
+### Inline visuals (REQUIRED)
+
+**Render these in the message itself. They are not an offer and not a follow-up** — a ranking, a
+trend or a split of a total delivered as prose is a defect in this skill's output.
+
+Scale bars from zero. Put the unit and the scale maximum on a label line above the visual. Cap at
+eight rows and roll the rest into `Other (n)`. Mark rows under the volume floor rather than drawing
+them to scale, and never bar a rate without its denominator in the row. **The visual replaces the
+prose it would have taken** — one sentence of interpretation underneath, never a restatement of the
+rows.
+
+Forms: unicode bar (`█`, scaled to the largest row) for rankings and splits; sparkline
+(`▁▂▃▄▅▆▇█`, first and last values labelled) for five or more periods; mermaid for structure only,
+never for quantity.
+
+| Whenever the run produced | Render |
+|---|---|
+| Five or more periods for a decaying ad | One sparkline per ad of CTR or cost per result against days live, first and last labelled — the decay curve is the finding, and prose cannot show it |
+| A refresh queue of three or more ads | Unicode bar of days remaining, shortest first, spend at risk in each row |
+| Frequency across four or more ads | Unicode bar of frequency with raw impressions in the row, so a high frequency on thin delivery is visible |
+
+**Render nothing** when there is a single figure, fewer than three comparable rows, an early exit,
+or a coverage table dominated by "not checkable". A two-row bar trains the reader to skip the
+visuals on the runs that have eight.
+
 ## G. Offer to build it out (CONDITIONAL)
+
+**The inline visuals above are not optional and are not this section's business.** This section
+covers only what *leaves the conversation* — a written record, a brief, a document, a pack. It
+**stays silent unless the run produced something a document carries better than the message already
+did.**
 
 | Found | Worth making | Why |
 |---|---|---|
-| Decay curves for three or more ads | CTR or cost per result against days live, one line per ad | The crossing point is the entire finding and prose cannot show it |
-| A frequency distribution with a long tail | A frequency histogram | The tail is invisible in the average |
-| A refresh queue going to whoever produces the creative | A written brief with the queue and the cadence | It leaves the conversation, and the cadence is the ask |
+| A refresh queue going to whoever produces the creative | A written brief with the queue and the monthly cadence arithmetic | It leaves the conversation, and the cadence is the ask |
 
-**Stay silent when** history is too short for curves, one ad is involved, or "not checkable"
-dominates. One thing, named by what it contains and who it is for. Never build it unasked.
+**Stay silent when** history is too short for a curve, one ad is involved, "not checkable"
+dominates, or the inline visuals above already carried the finding. One thing, named by what it
+contains and who it is for — never a menu. Never build it unasked; never delay the answer to make
+it.
 
 ## H. Save what you learned
 

--- a/marketing-and-ads/facebook-ads/facebook-ads-performance-review/SKILL.md
+++ b/marketing-and-ads/facebook-ads/facebook-ads-performance-review/SKILL.md
@@ -50,6 +50,8 @@ These override everything below:
 - **Speak at the coverage read**, before the data query. It is output, not preparation, and it prunes
   the rest of the run.
 - **Missing data is a line in the write-up, not a gate.** Don't stop mid-run to ask about it.
+- **Render rankings, trends and splits as inline visuals** in the message. They are part of the
+  answer, not something to offer afterwards.
 - **Don't narrate steps.** The user wants the read, not the itinerary.
 
 ## A. Connect to Coupler.io (HARD GATE)
@@ -150,23 +152,47 @@ Key Metrics = spend, cost per result, CPM, CTR, frequency, each with its delta �
 the attribution window, the period cap · Recommendations = which campaigns to look at and which
 sibling answers the next question.
 
+### Inline visuals (REQUIRED)
+
+**Render these in the message itself. They are not an offer and not a follow-up** — a ranking, a
+trend or a split of a total delivered as prose is a defect in this skill's output.
+
+Scale bars from zero. Put the unit and the scale maximum on a label line above the visual. Cap at
+eight rows and roll the rest into `Other (n)`. Mark rows under the volume floor rather than drawing
+them to scale, and never bar a rate without its denominator in the row. **The visual replaces the
+prose it would have taken** — one sentence of interpretation underneath, never a restatement of the
+rows.
+
+Forms: unicode bar (`█`, scaled to the largest row) for rankings and splits; sparkline
+(`▁▂▃▄▅▆▇█`, first and last values labelled) for five or more periods; mermaid for structure only,
+never for quantity.
+
+| Whenever the run produced | Render |
+|---|---|
+| Five or more periods of CPM, CTR, frequency or cost per result | A sparkline on each metric's Key Metrics line, first and last labelled — the delta and the shape in one row |
+| Three or more campaigns contributing to one account delta | Unicode bar of each campaign's contribution to the change, in currency, largest first |
+| A spend mix that shifted between periods | Two unicode bars of share of spend — prior, then current — in the same campaign order |
+
+**Render nothing** when there is a single figure, fewer than three comparable rows, an early exit,
+or a coverage table dominated by "not checkable". A two-row bar trains the reader to skip the
+visuals on the runs that have eight.
+
 ## G. Offer to build it out (CONDITIONAL)
 
-The written answer is complete. Offer one thing on top of it only when the run produced something a
-picture carries better than the message did.
+**The inline visuals above are not optional and are not this section's business.** This section
+covers only what *leaves the conversation* — a written record, a brief, a document, a pack. It
+**stays silent unless the run produced something a document carries better than the message already
+did.**
 
 | Found | Worth making | Why |
 |---|---|---|
-| A CPM or frequency trend over several weeks | A trend line with the baseline marked | A curve is a shape; a sentence about it is not |
-| Four or more campaigns contributing to one delta | A contribution waterfall | Shows where the change actually came from |
 | A read going to someone who was not in this conversation | A written record for the account file | It has to survive being forwarded |
 
-**Stay silent when** the run was an early exit, there is one finding, or "not checkable" dominates
-the coverage table.
-
-**One thing, named by what it contains and who it is for** — never a menu. If the monthly client pack
-is what they actually want, route to `facebook-ads-client-report` rather than building a deck here.
-Never build it unasked; never delay the answer to make it.
+**Stay silent when** the run was an early exit, there is one finding, "not checkable" dominates the
+coverage table, or the inline visuals above already carried the finding. One thing, named by what it
+contains and who it is for — never a menu. If the monthly client pack is what they actually want,
+route to `facebook-ads-client-report` rather than building a deck here. Never build it unasked;
+never delay the answer to make it.
 
 ## H. Save what you learned
 

--- a/marketing-and-ads/facebook-ads/facebook-ads-pixel-and-attribution-audit/SKILL.md
+++ b/marketing-and-ads/facebook-ads/facebook-ads-pixel-and-attribution-audit/SKILL.md
@@ -49,7 +49,8 @@ confident nonsense on a broken measurement layer.
 
 Overriding rules: never spend a call proving the connection works; speak at the coverage read;
 coverage prunes the run, so do not query for checks the schema already killed; missing data is a line
-in the write-up, not a gate; don't narrate steps.
+in the write-up, not a gate; don't narrate steps; render rankings, trends and splits as inline
+visuals in the message rather than offering to make them.
 
 ## A. Connect to Coupler.io (HARD GATE)
 
@@ -149,17 +150,46 @@ event count, view-through share, modelled share · Context = coverage and what w
 Recommendations = the defect list ordered by cost, each with its fix and its confirmed-or-suspected
 mark.
 
+### Inline visuals (REQUIRED)
+
+**Render these in the message itself. They are not an offer and not a follow-up** — a ranking, a
+trend or a split of a total delivered as prose is a defect in this skill's output.
+
+Scale bars from zero. Put the unit and the scale maximum on a label line above the visual. Cap at
+eight rows and roll the rest into `Other (n)`. Mark rows under the volume floor rather than drawing
+them to scale, and never bar a rate without its denominator in the row. **The visual replaces the
+prose it would have taken** — one sentence of interpretation underneath, never a restatement of the
+rows.
+
+Forms: unicode bar (`█`, scaled to the largest row) for rankings and splits; sparkline
+(`▁▂▃▄▅▆▇█`, first and last values labelled) for five or more periods; mermaid for structure only,
+never for quantity.
+
+| Whenever the run produced | Render |
+|---|---|
+| Three or more events carrying volume | Unicode bar of event volume, cost per event in the row — the wrong-event problem is visible in one look |
+| Tracked against untracked spend | Two-row unicode bar of the split, both figures and the share of total spend |
+| A dated tracking break with five or more days either side | Sparkline of daily events with the break date named directly beneath it |
+| Reported conversions split by click, view-through and modelled | Unicode bar of the three shares against the stated total |
+
+**Render nothing** when there is a single figure, fewer than three comparable rows, an early exit,
+or a coverage table dominated by "not checkable". A two-row bar trains the reader to skip the
+visuals on the runs that have eight.
+
 ## G. Offer to build it out (CONDITIONAL)
+
+**The inline visuals above are not optional and are not this section's business.** This section
+covers only what *leaves the conversation* — a written record, a brief, a document, a pack. It
+**stays silent unless the run produced something a document carries better than the message already
+did.**
 
 | Found | Worth making | Why |
 |---|---|---|
-| Three or more events carrying volume | A volume-and-cost comparison by event | Shows the wrong-event problem at a glance |
-| Untracked spend spread across several campaigns | A tracked-against-untracked spend split | Makes the share argument visually |
-| A dated tracking break | A daily event series with the break marked | The date is the whole argument |
-| A defect list of three or more going to someone outside this conversation | A written audit record | It has to survive being forwarded |
+| A defect list of three or more going to someone outside this conversation | A written audit record with each defect, its cost and its fix | It has to survive being forwarded |
 
-**Stay silent when** the numbers are clean, there is one finding, or "not checkable" dominates.
-One thing, named by what it contains and who it is for. Never build it unasked.
+**Stay silent when** the numbers are clean, there is one finding, "not checkable" dominates, or the
+inline visuals above already carried the finding. One thing, named by what it contains and who it is
+for — never a menu. Never build it unasked; never delay the answer to make it.
 
 ## H. Save what you learned
 

--- a/marketing-and-ads/facebook-ads/facebook-ads-placement-geo-and-device/SKILL.md
+++ b/marketing-and-ads/facebook-ads/facebook-ads-placement-geo-and-device/SKILL.md
@@ -44,7 +44,8 @@ apart.
 → one combined query. **Two calls** when the dataset is known.
 
 Overriding rules: never spend a call proving the connection works; speak at the coverage read;
-missing data is a line in the write-up, not a gate; don't narrate steps.
+missing data is a line in the write-up, not a gate; don't narrate steps; render rankings, trends and
+splits as inline visuals in the message rather than offering to make them.
 
 ## A. Connect to Coupler.io (HARD GATE)
 
@@ -143,17 +144,47 @@ Key Metrics = cost per result and share of spend for each placement, the top and
 device split · Context = coverage, volume floors, the dayparting limit, which timezone the hourly read
 uses · Recommendations = exclusions with the learning caveat attached, ranked by money.
 
+### Inline visuals (REQUIRED)
+
+**Render these in the message itself. They are not an offer and not a follow-up** — a ranking, a
+trend or a split of a total delivered as prose is a defect in this skill's output.
+
+Scale bars from zero. Put the unit and the scale maximum on a label line above the visual. Cap at
+eight rows and roll the rest into `Other (n)`. Mark rows under the volume floor rather than drawing
+them to scale, and never bar a rate without its denominator in the row. **The visual replaces the
+prose it would have taken** — one sentence of interpretation underneath, never a restatement of the
+rows.
+
+Forms: unicode bar (`█`, scaled to the largest row) for rankings and splits; sparkline
+(`▁▂▃▄▅▆▇█`, first and last values labelled) for five or more periods; mermaid for structure only,
+never for quantity.
+
+| Whenever the run produced | Render |
+|---|---|
+| Three or more placements above the floor | Two unicode bars in the same placement order — cost per result, then share of spend. **The mismatch between the two bars is the entire finding**, and it is invisible in prose |
+| An hour-of-day or weekday pattern with five or more points | Sparkline across the cycle with the timezone named on the label line |
+| Three or more markets above the floor | Unicode bar of cost per result by market, results count in each row |
+| A device split | Two-row unicode bar of share of spend, cost per result in each row |
+
+**Render nothing** when there is a single figure, fewer than three comparable rows, an early exit,
+or a coverage table dominated by "not checkable". A two-row bar trains the reader to skip the
+visuals on the runs that have eight.
+
 ## G. Offer to build it out (CONDITIONAL)
+
+**The inline visuals above are not optional and are not this section's business.** This section
+covers only what *leaves the conversation* — a written record, a brief, a document, a pack. It
+**stays silent unless the run produced something a document carries better than the message already
+did.**
 
 | Found | Worth making | Why |
 |---|---|---|
-| Four or more placements with different cost per result | A ranked bar with share of spend alongside | Two quantities per placement is exactly what a chart carries and prose does not |
-| A clear hour-of-day or weekday curve | The curve, with the account average marked | A curve is a shape |
-| A geographic spread across several markets | A market comparison table or map | Reads faster than a list |
-| Exclusion recommendations going to whoever will action them | A written record with the caveats | The learning caveat must travel with the recommendation or it will be ignored |
+| Exclusion recommendations going to whoever will action them | A written record with the learning caveat attached to each exclusion | The caveat must travel with the recommendation or the exclusion gets made blind |
 
-**Stay silent when** one placement dominates, cells are below the floor, or "not checkable" dominates
-coverage. One thing, named by what it contains and who it is for. Never build it unasked.
+**Stay silent when** one placement dominates, cells are below the floor, "not checkable" dominates
+coverage, or the inline visuals above already carried the finding. One thing, named by what it
+contains and who it is for — never a menu. Never build it unasked; never delay the answer to make
+it.
 
 ## H. Save what you learned
 

--- a/marketing-and-ads/facebook-ads/facebook-ads-settings-audit/SKILL.md
+++ b/marketing-and-ads/facebook-ads/facebook-ads-settings-audit/SKILL.md
@@ -47,7 +47,8 @@ one combined query. **Two calls** when it is known.
 
 Overriding rules: never spend a call proving the connection works; speak at the coverage read;
 coverage prunes the run, so do not chase settings the data does not carry; missing data is a line in
-the write-up, not a gate; don't narrate steps.
+the write-up, not a gate; don't narrate steps; render rankings, trends and splits as inline visuals
+in the message rather than offering to make them.
 
 ## A. Connect to Coupler.io (HARD GATE)
 
@@ -147,17 +148,47 @@ spend running through defective settings, count of defects by category, spend bl
 issues · Context = coverage, what was read from settings and what was inferred · Recommendations = the
 priced defect list in order, each with its fix.
 
+### Inline visuals (REQUIRED)
+
+**Render these in the message itself. They are not an offer and not a follow-up** — a ranking, a
+trend or a split of a total delivered as prose is a defect in this skill's output.
+
+Scale bars from zero. Put the unit and the scale maximum on a label line above the visual. Cap at
+eight rows and roll the rest into `Other (n)`. Mark rows under the volume floor rather than drawing
+them to scale, and never bar a rate without its denominator in the row. **The visual replaces the
+prose it would have taken** — one sentence of interpretation underneath, never a restatement of the
+rows.
+
+Forms: unicode bar (`█`, scaled to the largest row) for rankings and splits; sparkline
+(`▁▂▃▄▅▆▇█`, first and last values labelled) for five or more periods; mermaid for structure only,
+never for quantity.
+
+| Whenever the run produced | Render |
+|---|---|
+| Three or more defects with spend attached | Unicode bar of spend running through each defect, most expensive first, the fix named in the row |
+| Spend concentrated in one setting state | Unicode bar splitting total spend by state — Advantage+ on, off, mixed — against the stated account total |
+| Delivery issues blocking spend | Two-row unicode bar of blocked against delivering spend |
+
+**Render nothing** when there is a single figure, fewer than three comparable rows, an early exit,
+or a coverage table dominated by "not checkable". A two-row bar trains the reader to skip the
+visuals on the runs that have eight.
+
 ## G. Offer to build it out (CONDITIONAL)
+
+**The inline visuals above are not optional and are not this section's business.** This section
+covers only what *leaves the conversation* — a written record, a brief, a document, a pack. It
+**stays silent unless the run produced something a document carries better than the message already
+did.**
 
 | Found | Worth making | Why |
 |---|---|---|
-| Six or more defects with spend attached | A priced defect table for the account file | It will be worked through over days, not read once |
-| An inherited or new account audit | A written account review document | It is a handover artefact by nature and it will be forwarded |
-| Spend concentrated in one defect category | A split of spend by setting state | One picture makes the case that a list does not |
+| Six or more defects that will be worked through over days | A priced defect table for the account file | It is worked through, not read once |
+| An inherited or newly taken-over account | A written account review document | It is a handover artefact by nature and it will be forwarded |
 
-**Stay silent when** the account is clean, there is one defect, or "not checkable" dominates coverage.
-One thing, named by what it contains and who it is for. If it is the client-facing version they want,
-route to `facebook-ads-client-report`. Never build it unasked.
+**Stay silent when** the account is clean, there is one defect, "not checkable" dominates coverage,
+or the inline visuals above already carried the finding. One thing, named by what it contains and
+who it is for — never a menu. If it is the client-facing version they want, route to
+`facebook-ads-client-report`. Never build it unasked; never delay the answer to make it.
 
 ## H. Save what you learned
 

--- a/marketing-and-ads/facebook-ads/facebook-ads-structure-and-learning-review/SKILL.md
+++ b/marketing-and-ads/facebook-ads/facebook-ads-structure-and-learning-review/SKILL.md
@@ -43,7 +43,8 @@ is "not working" when the real answer is that there are too many of them.
 → one combined query. **Two calls** when the dataset is known.
 
 Overriding rules: never spend a call proving the connection works; speak at the coverage read;
-missing data is a line in the write-up, not a gate; don't narrate steps.
+missing data is a line in the write-up, not a gate; don't narrate steps; render rankings, trends and
+splits as inline visuals in the message rather than offering to make them.
 
 ## A. Connect to Coupler.io (HARD GATE)
 
@@ -139,16 +140,46 @@ Key Metrics = ad set count, budget per ad set, median weekly events, spend at ri
 Context = coverage, what is inferred rather than evidenced, the fifty-event threshold as Meta's
 guidance rather than a law · Recommendations = the consolidation lines with combined events after.
 
+### Inline visuals (REQUIRED)
+
+**Render these in the message itself. They are not an offer and not a follow-up** — a ranking, a
+trend or a split of a total delivered as prose is a defect in this skill's output.
+
+Scale bars from zero. Put the unit and the scale maximum on a label line above the visual. Cap at
+eight rows and roll the rest into `Other (n)`. Mark rows under the volume floor rather than drawing
+them to scale, and never bar a rate without its denominator in the row. **The visual replaces the
+prose it would have taken** — one sentence of interpretation underneath, never a restatement of the
+rows.
+
+Forms: unicode bar (`█`, scaled to the largest row) for rankings and splits; sparkline
+(`▁▂▃▄▅▆▇█`, first and last values labelled) for five or more periods; mermaid for structure only,
+never for quantity.
+
+| Whenever the run produced | Render |
+|---|---|
+| Weekly events across four or more ad sets | Unicode bar of weekly events with the fifty-event threshold stated on the label line and every row below it marked — **the threshold line is the entire argument** |
+| A spend split between learning and stable ad sets | Two-row unicode bar with both figures and the share |
+| A reset ledger covering five or more days | Sparkline of daily spend with the edit dates named beneath it — the correlation is only visible on a timeline |
+| A consolidation proposal | Unicode bar of events per ad set before and after, in the same order |
+
+**Render nothing** when there is a single figure, fewer than three comparable rows, an early exit,
+or a coverage table dominated by "not checkable". A two-row bar trains the reader to skip the
+visuals on the runs that have eight.
+
 ## G. Offer to build it out (CONDITIONAL)
+
+**The inline visuals above are not optional and are not this section's business.** This section
+covers only what *leaves the conversation* — a written record, a brief, a document, a pack. It
+**stays silent unless the run produced something a document carries better than the message already
+did.**
 
 | Found | Worth making | Why |
 |---|---|---|
-| Weekly events across eight or more ad sets | A ranked bar with the fifty-event line marked | The threshold line is the entire argument |
-| A dated reset ledger | A daily spend series with edits marked | The correlation is only visible on a timeline |
-| A consolidation proposal going to whoever will action it | A written record with before and after events | It has to survive being forwarded, and the arithmetic is the persuasion |
+| A consolidation proposal going to whoever will action it | A written record with before-and-after events | It has to survive being forwarded, and the arithmetic is the persuasion |
 
-**Stay silent when** the structure is fine, there is one finding, or "not checkable" dominates.
-One thing, named by what it contains and who it is for. Never build it unasked.
+**Stay silent when** the structure is fine, there is one finding, "not checkable" dominates, or the
+inline visuals above already carried the finding. One thing, named by what it contains and who it is
+for — never a menu. Never build it unasked; never delay the answer to make it.
 
 ## H. Save what you learned
 

--- a/marketing-and-ads/facebook-ads/facebook-ads-waste-and-scale/SKILL.md
+++ b/marketing-and-ads/facebook-ads/facebook-ads-waste-and-scale/SKILL.md
@@ -41,7 +41,8 @@ destination costs twice. This skill will not give you one list without the other
 → one combined query. **Two calls** when the dataset is known.
 
 Overriding rules: never spend a call proving the connection works; speak at the coverage read;
-missing data is a line in the write-up, not a gate; don't narrate steps.
+missing data is a line in the write-up, not a gate; don't narrate steps; render rankings, trends and
+splits as inline visuals in the message rather than offering to make them.
 
 ## A. Connect to Coupler.io (HARD GATE)
 
@@ -143,16 +144,46 @@ freed, redeployed, net, and the projected change in results · Context = the tar
 the significance floor, lines excluded for learning · Recommendations = the paired cut and scale
 lines, each with its number and its ceiling.
 
+### Inline visuals (REQUIRED)
+
+**Render these in the message itself. They are not an offer and not a follow-up** — a ranking, a
+trend or a split of a total delivered as prose is a defect in this skill's output.
+
+Scale bars from zero. Put the unit and the scale maximum on a label line above the visual. Cap at
+eight rows and roll the rest into `Other (n)`. Mark rows under the volume floor rather than drawing
+them to scale, and never bar a rate without its denominator in the row. **The visual replaces the
+prose it would have taken** — one sentence of interpretation underneath, never a restatement of the
+rows.
+
+Forms: unicode bar (`█`, scaled to the largest row) for rankings and splits; sparkline
+(`▁▂▃▄▅▆▇█`, first and last values labelled) for five or more periods; mermaid for structure only,
+never for quantity.
+
+| Whenever the run produced | Render |
+|---|---|
+| A cost-per-result spread across four or more lines | Unicode bar, ranked, with the target stated on the label line and every row past it marked, results count in each row — **the target line is the argument** |
+| A reallocation across three or more lines | Two unicode bars of the same total — before, then after — in the same line order |
+| Freed spend and where it goes | Unicode bar splitting the freed total across its destinations, with the net figure written out |
+
+**Render nothing** when there is a single figure, fewer than three comparable rows, an early exit,
+or a coverage table dominated by "not checkable". A two-row bar trains the reader to skip the
+visuals on the runs that have eight.
+
 ## H. Offer to build it out (CONDITIONAL)
+
+**The inline visuals above are not optional and are not this section's business.** This section
+covers only what *leaves the conversation* — a written record, a brief, a document, a pack. It
+**stays silent unless the run produced something a document carries better than the message already
+did.**
 
 | Found | Worth making | Why |
 |---|---|---|
-| A reallocation across four or more lines | A before-and-after spend split | It is a split of a total, which is what charts do best |
 | A cut list going to someone who will action it later | A written record with the numbers and the reasoning | It has to survive being forwarded, and the reasoning is what stops it being half-actioned |
-| A cost-per-result distribution with a clear tail | A ranked bar with the target line marked | The target line is the argument |
 
-**Stay silent when** the list is one or two lines, or the target was a substitute and everything is
-provisional. One thing, named by what it contains and who it is for. Never build it unasked.
+**Stay silent when** the list is one or two lines, the target was a substitute and everything is
+provisional, or the inline visuals above already carried the finding. One thing, named by what it
+contains and who it is for — never a menu. Never build it unasked; never delay the answer to make
+it.
 
 ## I. Save what you learned
 


### PR DESCRIPTION
The eleven Facebook skills already named good charts -- "ranked bar with the target line marked", "CTR against days live, one line per ad", "cost per result and frequency on one chart, the crossing point is the finding". Every one of them sat in the conditional Offer section, which is written to stay silent, so they were almost never built. Runs came back as 2,000 words of prose.

Per skill:

* "How to run this" gains an overriding rule beside "speak at the coverage read": render rankings, trends and splits as inline visuals in the message rather than offering to make them. It binds before the skill reaches Deliver.

* Deliver gains "### Inline visuals (REQUIRED)" -- the shared honesty rules (scale from zero, unit and scale maximum on a label line, cap at eight rows with a rolled-up Other, mark rows under the volume floor instead of scaling them, never bar a rate without its denominator, the visual replaces the prose it would have taken) and a "whenever the run produced -> render" table naming that skill's own visuals. Forms are unicode bar, sparkline and mermaid, so nothing needs a library, a file or a round trip.

* Offer is rescoped to what leaves the conversation -- written records, briefs, documents, the client pack. Chart rows moved up into Deliver. Each stay-silent clause gains "or the inline visuals above already carried the finding".

Where the promotion sharpened the finding rather than relocating it: placement-geo-and-device pairs cost per result with share of spend in the same row order, because the mismatch between the two bars is the finding; structure-and-learning-review puts the fifty-event threshold on the label line and marks every row below it; client-report caps the Summary at two visuals but always carries the target-against-actual bar in the misses section, since a miss explained only in prose reads as a miss being buried.

No section letters moved, no frontmatter touched, no other section edited. skills-index.json is generated from frontmatter, so it needs no update.

Follows the section G rewrite in skill-anatomy.md. The google-ads and tiktok-ads packs and ppc-analytics are not yet migrated.


Claude-Session: https://claude.ai/code/session_0153GQSUHkGFQESFwLZ89fUc