### PR TITLE
[CPL-26754] Strengthen skill name validation

### DIFF
--- a/.github/scripts/generate_skill_index.py
+++ b/.github/scripts/generate_skill_index.py
@@ -199,13 +199,15 @@ def main(argv: list[str] | None = None) -> int:
     invalid_names = find_invalid_skill_names(skills)
     mismatches = find_name_directory_mismatches(skills)
     duplicate_names = find_duplicate_skill_names(skills)
+
+    if invalid_names:
+        print_invalid_names(invalid_names)
+    if mismatches:
+        print_name_directory_mismatches(mismatches)
+    if duplicate_names:
+        print_duplicate_names(duplicate_names)
+
     if invalid_names or mismatches or duplicate_names:
-        if invalid_names:
-            print_invalid_names(invalid_names)
-        if mismatches:
-            print_name_directory_mismatches(mismatches)
-        if duplicate_names:
-            print_duplicate_names(duplicate_names)
         return 1
 
     if args.check:

--- a/.github/scripts/generate_skill_index.py
+++ b/.github/scripts/generate_skill_index.py
@@ -83,28 +83,29 @@ def collect_skills(repo_root: Path) -> list[dict[str, Any]]:
     return skills
 
 
-def parameterize(value: str) -> str:
-    # Matches Ruby's String#parameterize: keeps _ distinct from -, so foo_bar and foo-bar are different slugs.
-    value = re.sub(r"[^a-zA-Z0-9\-_]+", "-", value)
-    value = re.sub(r"-{2,}", "-", value)
-    value = value.strip("-")
-    return value.lower()
+NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$")
+
+
+def find_invalid_skill_names(skills: list[dict[str, Any]]) -> list[dict[str, str]]:
+    return [
+        {"path": skill["path"], "name": skill["name"]}
+        for skill in skills
+        if not NAME_PATTERN.match(skill["name"])
+    ]
 
 
 def find_duplicate_skill_names(skills: list[dict[str, Any]]) -> dict[str, list[str]]:
     by_name: dict[str, list[str]] = {}
     for skill in skills:
-        slug = parameterize(skill["name"])
-        by_name.setdefault(slug, []).append(skill["path"])
-    return {slug: paths for slug, paths in by_name.items() if len(paths) > 1}
+        by_name.setdefault(skill["name"], []).append(skill["path"])
+    return {name: paths for name, paths in by_name.items() if len(paths) > 1}
 
 
 def find_name_directory_mismatches(skills: list[dict[str, Any]]) -> list[dict[str, str]]:
     mismatches = []
     for skill in skills:
-        leaf = parameterize(skill["path"].split("/")[-1])
-        name_slug = parameterize(skill["name"])
-        if leaf != name_slug:
+        leaf = skill["path"].split("/")[-1]
+        if leaf != skill["name"]:
             mismatches.append({"path": skill["path"], "name": skill["name"]})
     return mismatches
 
@@ -133,6 +134,20 @@ def render_index(skills: list[dict[str, Any]]) -> str:
 def write_index(skills: list[dict[str, Any]], output: Path) -> None:
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(render_index(skills), encoding="utf-8")
+
+
+def print_invalid_names(invalid: list[dict[str, str]]) -> None:
+    for skill in invalid:
+        print(
+            f"Invalid skill name {skill['name']!r}: {skill['path']}",
+            file=sys.stderr,
+        )
+
+    print(
+        "\nA skill's `name` may only contain lowercase ASCII letters, digits, "
+        "- and _, and can't start or end with - or _.",
+        file=sys.stderr,
+    )
 
 
 def print_duplicate_names(duplicates: dict[str, list[str]]) -> None:
@@ -173,7 +188,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Validate without writing; exit 1 on duplicate or mismatched skill names",
+        help="Validate without writing; exit 1 on invalid, duplicate, or mismatched skill names",
     )
     args = parser.parse_args(argv)
 
@@ -181,9 +196,12 @@ def main(argv: list[str] | None = None) -> int:
     output = args.output.resolve()
     skills = collect_skills(root)
 
+    invalid_names = find_invalid_skill_names(skills)
     duplicate_names = find_duplicate_skill_names(skills)
     mismatches = find_name_directory_mismatches(skills)
-    if duplicate_names or mismatches:
+    if invalid_names or duplicate_names or mismatches:
+        if invalid_names:
+            print_invalid_names(invalid_names)
         if duplicate_names:
             print_duplicate_names(duplicate_names)
         if mismatches:
@@ -191,7 +209,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     if args.check:
-        print(f"OK: {len(skills)} skills, all names unique and matching their folders")
+        print(f"OK: {len(skills)} skills, all names valid, unique, and matching their folders")
         return 0
 
     write_index(skills, output)

--- a/.github/scripts/generate_skill_index.py
+++ b/.github/scripts/generate_skill_index.py
@@ -197,15 +197,15 @@ def main(argv: list[str] | None = None) -> int:
     skills = collect_skills(root)
 
     invalid_names = find_invalid_skill_names(skills)
-    duplicate_names = find_duplicate_skill_names(skills)
     mismatches = find_name_directory_mismatches(skills)
-    if invalid_names or duplicate_names or mismatches:
+    duplicate_names = find_duplicate_skill_names(skills)
+    if invalid_names or mismatches or duplicate_names:
         if invalid_names:
             print_invalid_names(invalid_names)
-        if duplicate_names:
-            print_duplicate_names(duplicate_names)
         if mismatches:
             print_name_directory_mismatches(mismatches)
+        if duplicate_names:
+            print_duplicate_names(duplicate_names)
         return 1
 
     if args.check:

--- a/.github/scripts/generate_skill_index.py
+++ b/.github/scripts/generate_skill_index.py
@@ -91,12 +91,22 @@ def parameterize(value: str) -> str:
     return value.lower()
 
 
-def find_duplicate_leaf_slugs(skills: list[dict[str, Any]]) -> dict[str, list[str]]:
-    by_leaf: dict[str, list[str]] = {}
+def find_duplicate_skill_names(skills: list[dict[str, Any]]) -> dict[str, list[str]]:
+    by_name: dict[str, list[str]] = {}
+    for skill in skills:
+        slug = parameterize(skill["name"])
+        by_name.setdefault(slug, []).append(skill["path"])
+    return {slug: paths for slug, paths in by_name.items() if len(paths) > 1}
+
+
+def find_name_directory_mismatches(skills: list[dict[str, Any]]) -> list[dict[str, str]]:
+    mismatches = []
     for skill in skills:
         leaf = parameterize(skill["path"].split("/")[-1])
-        by_leaf.setdefault(leaf, []).append(skill["path"])
-    return {leaf: paths for leaf, paths in by_leaf.items() if len(paths) > 1}
+        name_slug = parameterize(skill["name"])
+        if leaf != name_slug:
+            mismatches.append({"path": skill["path"], "name": skill["name"]})
+    return mismatches
 
 
 INDEX_README = (
@@ -125,18 +135,33 @@ def write_index(skills: list[dict[str, Any]], output: Path) -> None:
     output.write_text(render_index(skills), encoding="utf-8")
 
 
-def print_duplicates(duplicates: dict[str, list[str]]) -> None:
-    for leaf, paths in duplicates.items():
-        print(f"Duplicate skill slug {leaf!r}:", file=sys.stderr)
+def print_duplicate_names(duplicates: dict[str, list[str]]) -> None:
+    for slug, paths in duplicates.items():
+        print(f"Duplicate skill name {slug!r}:", file=sys.stderr)
         for path in paths:
             print(f"  {path}", file=sys.stderr)
 
     print(
-        "\nEvery skill's file is always named SKILL.md - what needs to be "
-        "unique is the FOLDER it lives in. If you just added one of these "
-        "skills, rename its folder to something no other skill uses. For "
-        "example:\n"
-        "  sales/analytics/SKILL.md  ->  sales/sales-analytics/SKILL.md",
+        "\nEach skill's `name` in SKILL.md frontmatter must be unique across "
+        "the repository. Rename one of the skills above (both the `name` "
+        "field and its folder) so they no longer collide.",
+        file=sys.stderr,
+    )
+
+
+def print_name_directory_mismatches(mismatches: list[dict[str, str]]) -> None:
+    for mismatch in mismatches:
+        print(
+            f"Skill folder doesn't match its name: {mismatch['path']} "
+            f"has name {mismatch['name']!r}",
+            file=sys.stderr,
+        )
+
+    print(
+        "\nEvery skill's file is always named SKILL.md - the FOLDER it "
+        "lives in must match its frontmatter `name`. For example:\n"
+        "  sales/sales-analytics/SKILL.md with name: sales-analytics  ->  valid\n"
+        "  sales/sales-analytics/SKILL.md with name: analytics        ->  invalid",
         file=sys.stderr,
     )
 
@@ -148,7 +173,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Validate without writing; exit 1 on duplicate leaf slugs",
+        help="Validate without writing; exit 1 on duplicate or mismatched skill names",
     )
     args = parser.parse_args(argv)
 
@@ -156,13 +181,17 @@ def main(argv: list[str] | None = None) -> int:
     output = args.output.resolve()
     skills = collect_skills(root)
 
-    duplicates = find_duplicate_leaf_slugs(skills)
-    if duplicates:
-        print_duplicates(duplicates)
+    duplicate_names = find_duplicate_skill_names(skills)
+    mismatches = find_name_directory_mismatches(skills)
+    if duplicate_names or mismatches:
+        if duplicate_names:
+            print_duplicate_names(duplicate_names)
+        if mismatches:
+            print_name_directory_mismatches(mismatches)
         return 1
 
     if args.check:
-        print(f"OK: {len(skills)} skills, no duplicate slugs")
+        print(f"OK: {len(skills)} skills, all names unique and matching their folders")
         return 0
 
     write_index(skills, output)


### PR DESCRIPTION
## Summary
Follow-up to https://github.com/coupler-io/skills/pull/10#discussion_r3966933611, which asked for two validations on `generate_skill_index.py`: skill names (from `SKILL.md` frontmatter) must be unique, and each skill's folder must match its own name.

- Validate `name` uniqueness across all `SKILL.md` files (not just directory-leaf uniqueness).
- Validate that each skill's folder matches its own `name`.
- Validate that `name` only contains lowercase ASCII letters, digits, `-`, `_`, and doesn't start/end with `-`/`_` — this makes `parameterize` unnecessary, so it's removed in favor of plain string comparisons.
- Checks run in order (pattern → folder match → uniqueness) and all errors are reported together in one run, not just the first failure.

## Test plan
- [x] `python3 .github/scripts/generate_skill_index.py --check` passes on the current repo (43 skills, all valid/unique/matching)
- [x] Manually verified each failure mode (invalid characters, duplicate names, folder/name mismatch) against synthetic fixtures — each produces the expected error and non-zero exit code